### PR TITLE
Add Ixeris

### DIFF
--- a/Fabric/1.19.4/modrinth.index.json
+++ b/Fabric/1.19.4/modrinth.index.json
@@ -1,129 +1,24 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "1.0.4",
+  "versionId": "1.1.0",
   "name": "Photon",
   "summary": "",
   "files": [
     {
-      "path": "mods/indium-1.0.19+mc1.19.4.jar",
+      "path": "mods/cloth-config-10.1.135-fabric.jar",
       "hashes": {
-        "sha512": "676e217ba05ff49c3e8d5d801f7c157b5b988eb21a44694d5c72a279dcdfe30933f57639a66d9f49b9b10c26edb288e8aa212ba27d4bd9abe0212c52b2e9b193",
-        "sha1": "55638e279d8a19ea5df67ff86feb6350e95376e1"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/Orvt0mRa/versions/oYQsfz9e/indium-1.0.19%2Bmc1.19.4.jar"
-      ],
-      "fileSize": 104841
-    },
-    {
-      "path": "mods/entityculling-fabric-1.8.2-mc1.19.4.jar",
-      "hashes": {
-        "sha1": "596137be484be7ebdeccae6009e587ee89cf1638",
-        "sha512": "a3a7dafae7defddae985f03ad7cf5c5b511352ceb8467c4d87245180375a1db2ebbec5ae709de687f64a6a157ea7669eda7c0be8e64b12dc71f38cf0b6a6eb49"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/NNAgCjsB/versions/Qu62cqxc/entityculling-fabric-1.8.2-mc1.19.4.jar"
-      ],
-      "fileSize": 471282
-    },
-    {
-      "path": "mods/phosphor-fabric-mc1.19.x-0.8.1.jar",
-      "hashes": {
-        "sha1": "2dd6f771ba5878d81892b9487f35340e94c87a1c",
-        "sha512": "13a0707b7a92726aa3154bc40978f36bb340d643c1d60e9fa2cbf8f7b0c7d3ea03c2a079f46a487df05e944eec9f5779afae9e99be7f70373e8a31d59948d487"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/hEOCdOgW/versions/mc1.19.x-0.8.1/phosphor-fabric-mc1.19.x-0.8.1.jar"
-      ],
-      "fileSize": 88018
-    },
-    {
-      "path": "mods/enhancedblockentities-0.9+1.19.4.jar",
-      "hashes": {
-        "sha512": "a60cbef0fc67789fafefafaf799107e17b96a2d1cf67f3b8396f8960a64308c9a9d33c822a0d62f6873bf2215c2026c46b78fa2d240c0055148230f13903636d",
-        "sha1": "97ffe54d7f5294fe6c8b529f51ef4b208b3ab1a7"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/OVuFYfre/versions/Xdo5ZiRc/enhancedblockentities-0.9%2B1.19.4.jar"
-      ],
-      "fileSize": 492518
-    },
-    {
-      "path": "mods/lithium-fabric-mc1.19.4-0.11.1.jar",
-      "hashes": {
-        "sha512": "f2bd271e30e5ed9f097d592db5e859208a1c6abe727dc51f83879b837c843b4f6453e99f1ca8d5225f896233ab8f7dbbb3300f10396d2a1cd2957937acfd1aa7",
-        "sha1": "69aa137957af4f0f701f6a7663c6d8646f84a1cc"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/14hWYkog/lithium-fabric-mc1.19.4-0.11.1.jar"
-      ],
-      "fileSize": 639391
-    },
-    {
-      "path": "mods/fabric-api-0.87.2+1.19.4.jar",
-      "hashes": {
-        "sha512": "d839c678699130db605ac580484b5193c302dfa1ed91014c138cb1354874cef0d16580c7c11bedece3cf8a027ddbb4755d4924f6045970a6af608ff0fed898eb",
-        "sha1": "586ac174c831da9fd35edce1e36eb14c7f878ce3"
+        "sha512": "b9aed46cff0bb4f33b55632de2234efc223d406cb33f264fc52048965c3570ae03d2493c5a93f46efd3bcf8c13f1d9cb420ff567f6c768108ddacb60918efbe6",
+        "sha1": "4f180acffa5c4abb1ed895c21265dc50b1420dff"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/P7dR8mSH/versions/nyAmoHlr/fabric-api-0.87.2%2B1.19.4.jar"
+        "https://cdn.modrinth.com/data/9s6osm5g/versions/ZTMfeJij/cloth-config-10.1.135-fabric.jar"
       ],
-      "fileSize": 2055860
-    },
-    {
-      "path": "mods/ImmediatelyFast-Fabric-1.2.11+1.19.4.jar",
-      "hashes": {
-        "sha1": "956a23c27590dd14195128708cd6e59b057a10dc",
-        "sha512": "c7b3443406357bad283d2214f4f99ff8760a60c60c228b2e40acc33e37409be87c3e7eebd4d33f460dd2697a25188361f8869a96e5cb2d34422a6107248d2e85"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/5ZwdcRci/versions/ezKTj0NE/ImmediatelyFast-Fabric-1.2.11%2B1.19.4.jar"
-      ],
-      "fileSize": 370128
-    },
-    {
-      "path": "mods/moreculling-1.19.4-0.17.0.jar",
-      "hashes": {
-        "sha1": "91d4fdb4786d2dfe56a84dff552bcadbebc88cec",
-        "sha512": "bf01675be88b4770f6fa6197644978912e9d3fd547c8eeeb709102088a15b0570043f5b05c93f7d600a08ff80dad1f00b3fd52f2fb1243f9268b837e6329be52"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/51shyZVL/versions/A9LKf67q/moreculling-1.19.4-0.17.0.jar"
-      ],
-      "fileSize": 1235479
+      "fileSize": 1171035
     },
     {
       "path": "mods/sodium-fabric-mc1.19.4-0.4.10+build.24.jar",
@@ -141,19 +36,34 @@
       "fileSize": 711302
     },
     {
-      "path": "mods/c2me-fabric-mc1.19.4-0.2.0+alpha.10.66.jar",
+      "path": "mods/enhancedblockentities-0.9+1.19.4.jar",
       "hashes": {
-        "sha1": "5c681eb7358d91faf52c7b57d590c4fa274a6847",
-        "sha512": "1cbb1fe9b3538d953e341b499c67001f9fb142bf24853a6133dbc091aa8757d47d9949a1bc04106676cfb0b3ac280409fe017c1e3d4194bf35bb606eaea6c79d"
+        "sha1": "97ffe54d7f5294fe6c8b529f51ef4b208b3ab1a7",
+        "sha512": "a60cbef0fc67789fafefafaf799107e17b96a2d1cf67f3b8396f8960a64308c9a9d33c822a0d62f6873bf2215c2026c46b78fa2d240c0055148230f13903636d"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/VSNURh3q/versions/uZ1nQtIu/c2me-fabric-mc1.19.4-0.2.0%2Balpha.10.66.jar"
+        "https://cdn.modrinth.com/data/OVuFYfre/versions/Xdo5ZiRc/enhancedblockentities-0.9%2B1.19.4.jar"
       ],
-      "fileSize": 1298898
+      "fileSize": 492518
+    },
+    {
+      "path": "mods/indium-1.0.19+mc1.19.4.jar",
+      "hashes": {
+        "sha512": "676e217ba05ff49c3e8d5d801f7c157b5b988eb21a44694d5c72a279dcdfe30933f57639a66d9f49b9b10c26edb288e8aa212ba27d4bd9abe0212c52b2e9b193",
+        "sha1": "55638e279d8a19ea5df67ff86feb6350e95376e1"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/Orvt0mRa/versions/oYQsfz9e/indium-1.0.19%2Bmc1.19.4.jar"
+      ],
+      "fileSize": 104841
     },
     {
       "path": "mods/ferritecore-5.2.0-fabric.jar",
@@ -171,6 +81,21 @@
       "fileSize": 124924
     },
     {
+      "path": "mods/lithium-fabric-mc1.19.4-0.11.1.jar",
+      "hashes": {
+        "sha1": "69aa137957af4f0f701f6a7663c6d8646f84a1cc",
+        "sha512": "f2bd271e30e5ed9f097d592db5e859208a1c6abe727dc51f83879b837c843b4f6453e99f1ca8d5225f896233ab8f7dbbb3300f10396d2a1cd2957937acfd1aa7"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/14hWYkog/lithium-fabric-mc1.19.4-0.11.1.jar"
+      ],
+      "fileSize": 639391
+    },
+    {
       "path": "mods/BadOptimizations-2.1.4-1.19.4.jar",
       "hashes": {
         "sha512": "2455f656b056a1e3365a90079a03ef16c0a0bb10571f2ad10f0870f16c55cb32c838d0ecfadc35726b28ee768522dadb80cd3a43aeb878fadcd348405741ee75",
@@ -186,38 +111,128 @@
       "fileSize": 422943
     },
     {
-      "path": "mods/cloth-config-10.1.135-fabric.jar",
+      "path": "mods/phosphor-fabric-mc1.19.x-0.8.1.jar",
       "hashes": {
-        "sha512": "b9aed46cff0bb4f33b55632de2234efc223d406cb33f264fc52048965c3570ae03d2493c5a93f46efd3bcf8c13f1d9cb420ff567f6c768108ddacb60918efbe6",
-        "sha1": "4f180acffa5c4abb1ed895c21265dc50b1420dff"
+        "sha1": "2dd6f771ba5878d81892b9487f35340e94c87a1c",
+        "sha512": "13a0707b7a92726aa3154bc40978f36bb340d643c1d60e9fa2cbf8f7b0c7d3ea03c2a079f46a487df05e944eec9f5779afae9e99be7f70373e8a31d59948d487"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/9s6osm5g/versions/ZTMfeJij/cloth-config-10.1.135-fabric.jar"
+        "https://cdn.modrinth.com/data/hEOCdOgW/versions/mc1.19.x-0.8.1/phosphor-fabric-mc1.19.x-0.8.1.jar"
       ],
-      "fileSize": 1171035
+      "fileSize": 88018
     },
     {
-      "path": "mods/modernfix-fabric-5.7.2+mc1.19.4.jar",
+      "path": "mods/entityculling-fabric-1.8.2-mc1.19.4.jar",
       "hashes": {
-        "sha512": "94877c4253224855753650e198df5cec908e4d07ae8f678982fa0a51a421d8f5659c2d505320a6af079da890bddca4f17d519484411bba877ca67fe545ec58b8",
-        "sha1": "53ec153757699d3998f74891d8ac8ef13b3da2aa"
+        "sha512": "a3a7dafae7defddae985f03ad7cf5c5b511352ceb8467c4d87245180375a1db2ebbec5ae709de687f64a6a157ea7669eda7c0be8e64b12dc71f38cf0b6a6eb49",
+        "sha1": "596137be484be7ebdeccae6009e587ee89cf1638"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/NNAgCjsB/versions/Qu62cqxc/entityculling-fabric-1.8.2-mc1.19.4.jar"
+      ],
+      "fileSize": 471282
+    },
+    {
+      "path": "mods/ImmediatelyFast-Fabric-1.2.11+1.19.4.jar",
+      "hashes": {
+        "sha512": "c7b3443406357bad283d2214f4f99ff8760a60c60c228b2e40acc33e37409be87c3e7eebd4d33f460dd2697a25188361f8869a96e5cb2d34422a6107248d2e85",
+        "sha1": "956a23c27590dd14195128708cd6e59b057a10dc"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
+        "https://cdn.modrinth.com/data/5ZwdcRci/versions/ezKTj0NE/ImmediatelyFast-Fabric-1.2.11%2B1.19.4.jar"
+      ],
+      "fileSize": 370128
+    },
+    {
+      "path": "mods/modernfix-fabric-5.7.2+mc1.19.4.jar",
+      "hashes": {
+        "sha1": "53ec153757699d3998f74891d8ac8ef13b3da2aa",
+        "sha512": "94877c4253224855753650e198df5cec908e4d07ae8f678982fa0a51a421d8f5659c2d505320a6af079da890bddca4f17d519484411bba877ca67fe545ec58b8"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
         "https://cdn.modrinth.com/data/nmDcB62a/versions/LXlsO4Vo/modernfix-fabric-5.7.2%2Bmc1.19.4.jar"
       ],
       "fileSize": 513020
+    },
+    {
+      "path": "mods/fabric-api-0.87.2+1.19.4.jar",
+      "hashes": {
+        "sha512": "d839c678699130db605ac580484b5193c302dfa1ed91014c138cb1354874cef0d16580c7c11bedece3cf8a027ddbb4755d4924f6045970a6af608ff0fed898eb",
+        "sha1": "586ac174c831da9fd35edce1e36eb14c7f878ce3"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/P7dR8mSH/versions/nyAmoHlr/fabric-api-0.87.2%2B1.19.4.jar"
+      ],
+      "fileSize": 2055860
+    },
+    {
+      "path": "mods/moreculling-1.19.4-0.17.0.jar",
+      "hashes": {
+        "sha1": "91d4fdb4786d2dfe56a84dff552bcadbebc88cec",
+        "sha512": "bf01675be88b4770f6fa6197644978912e9d3fd547c8eeeb709102088a15b0570043f5b05c93f7d600a08ff80dad1f00b3fd52f2fb1243f9268b837e6329be52"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/51shyZVL/versions/A9LKf67q/moreculling-1.19.4-0.17.0.jar"
+      ],
+      "fileSize": 1235479
+    },
+    {
+      "path": "mods/ixeris-3.4.0+1.20.1-fabric.jar",
+      "hashes": {
+        "sha1": "9808bd7c484a859ef8206c7b84a6435179c0c381",
+        "sha512": "04793bf2ee38c94d13ba3843fa139b4c225fe474f31f66c0d7583fb9942f198c3e4f944fa94b8978df8a75e757d021437e804c3001c0deb338675871e4e1a0dd"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/6W1bmIHf/ixeris-3.4.0%2B1.20.1-fabric.jar"
+      ],
+      "fileSize": 152331
+    },
+    {
+      "path": "mods/c2me-fabric-mc1.19.4-0.2.0+alpha.10.66.jar",
+      "hashes": {
+        "sha1": "5c681eb7358d91faf52c7b57d590c4fa274a6847",
+        "sha512": "1cbb1fe9b3538d953e341b499c67001f9fb142bf24853a6133dbc091aa8757d47d9949a1bc04106676cfb0b3ac280409fe017c1e3d4194bf35bb606eaea6c79d"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/VSNURh3q/versions/uZ1nQtIu/c2me-fabric-mc1.19.4-0.2.0%2Balpha.10.66.jar"
+      ],
+      "fileSize": 1298898
     }
   ],
   "dependencies": {
-    "minecraft": "1.19.4",
-    "fabric-loader": "0.16.14"
+    "fabric-loader": "0.17.0",
+    "minecraft": "1.19.4"
   }
 }

--- a/Fabric/1.20.1/modrinth.index.json
+++ b/Fabric/1.20.1/modrinth.index.json
@@ -1,69 +1,69 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "1.0.15",
+  "versionId": "1.1.0",
   "name": "Photon",
   "summary": "",
   "files": [
     {
-      "path": "mods/fabric-api-0.92.6+1.20.1.jar",
+      "path": "mods/BadOptimizations-2.3.0-1.20.1.jar",
       "hashes": {
-        "sha512": "2bd2ed0cee22305b7ff49597c103a57c8fbe5f64be54a906796d48b589862626c951ff4cbf5cb1ed764a4d6479d69c3077594e693b7a291240eeea2bb3132b0c",
-        "sha1": "3ec0a88b64f252257df6287e9a1d47ed96331e5d"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/P7dR8mSH/versions/UapVHwiP/fabric-api-0.92.6%2B1.20.1.jar"
-      ],
-      "fileSize": 2107873
-    },
-    {
-      "path": "mods/ImmediatelyFast-Fabric-1.5.1+1.20.4.jar",
-      "hashes": {
-        "sha1": "4050cb966b7211c234494075769bc8baf33e3c31",
-        "sha512": "23ddba94cb88591a9381b16c1e8ac2f59a609407d4e3400c083f85d416c37d5a7c42c67d6908d92a98f84fdf93ad083b9c5e8a041a1d90b0ffcca573ab0d3d92"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/5ZwdcRci/versions/zJD8Yaa3/ImmediatelyFast-Fabric-1.5.1%2B1.20.4.jar"
-      ],
-      "fileSize": 242574
-    },
-    {
-      "path": "mods/noisium-fabric-2.3.0+mc1.20-1.20.1.jar",
-      "hashes": {
-        "sha1": "be85535cf1efe82bd8c41bcf851becaad498a598",
-        "sha512": "f0abcdac514bd2b4eb6af3529eeb9980a6fef534d31244879acb291a9943151aeb34f372bf98ae01f6191870bf95e1c0bc36d522433353a1090b96e7ac03c417"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/KuNKN7d2/versions/erSJnRcq/noisium-fabric-2.3.0%2Bmc1.20-1.20.1.jar"
-      ],
-      "fileSize": 214902
-    },
-    {
-      "path": "mods/modernfix-fabric-5.24.4+mc1.20.1.jar",
-      "hashes": {
-        "sha512": "f56b3e3761af6031ecd4cab5b3dc143cbd47d97e0a5eb8138bd579bd6c169687d5affa154c71992703ffddb2e99f3e6c3852fb554ee0321467ffc6a8cc301a28",
-        "sha1": "3d20fa94c463113a24346ed544f4ca95c54bae8d"
+        "sha512": "288638bd5e4d9163205006ddc06eb6d962abcf9c49b602eeef3389e56184deee7844037a7cd41f770d6088a063756380afe1a6c456668356dd56b238834c3c49",
+        "sha1": "b86ce6a5ed4f71a13f6d2976ffe6471cef29beb7"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/nmDcB62a/versions/PSpecC1r/modernfix-fabric-5.24.4%2Bmc1.20.1.jar"
+        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/RPOjbIwJ/BadOptimizations-2.3.0-1.20.1.jar"
       ],
-      "fileSize": 533705
+      "fileSize": 452304
+    },
+    {
+      "path": "mods/enhancedblockentities-0.9+1.20.jar",
+      "hashes": {
+        "sha512": "7e8b402fd25efd396bc7f0f25a663808ae9890accc227850c454dfcdc975657f22afceb15878e781485622434a6f6d60aff2a60264aa4425edd52ebe052a0de5",
+        "sha1": "61cfe50f69f8ef9e3640c0269ef158870f5b0410"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/OVuFYfre/versions/i3v1Skck/enhancedblockentities-0.9%2B1.20.jar"
+      ],
+      "fileSize": 490690
+    },
+    {
+      "path": "mods/cloth-config-11.1.136-fabric.jar",
+      "hashes": {
+        "sha1": "d5fe84a0cc9ed5c7290a76ba570e1f8716afecab",
+        "sha512": "2da85c071c854223cc30c8e46794391b77e53f28ecdbbde59dc83b3dbbdfc74be9e68da9ed464e7f98b4361033899ba4f681ebff1f35edc2c60e599a59796f1c"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/9s6osm5g/versions/2xQdCMyG/cloth-config-11.1.136-fabric.jar"
+      ],
+      "fileSize": 1172214
+    },
+    {
+      "path": "mods/ferritecore-6.0.1-fabric.jar",
+      "hashes": {
+        "sha512": "9b7dc686bfa7937815d88c7bbc6908857cd6646b05e7a96ddbdcada328a385bd4ba056532cd1d7df9d2d7f4265fd48bd49ff683f217f6d4e817177b87f6bc457",
+        "sha1": "8fa3b84fc5860dbc30fdf8cced02af68dffcf3fa"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/uXXizFIs/versions/unerR5MN/ferritecore-6.0.1-fabric.jar"
+      ],
+      "fileSize": 125197
     },
     {
       "path": "mods/entityculling-fabric-1.8.2-mc1.20.1.jar",
@@ -81,85 +81,10 @@
       "fileSize": 470860
     },
     {
-      "path": "mods/BadOptimizations-2.3.0-1.20.1.jar",
-      "hashes": {
-        "sha1": "b86ce6a5ed4f71a13f6d2976ffe6471cef29beb7",
-        "sha512": "288638bd5e4d9163205006ddc06eb6d962abcf9c49b602eeef3389e56184deee7844037a7cd41f770d6088a063756380afe1a6c456668356dd56b238834c3c49"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/RPOjbIwJ/BadOptimizations-2.3.0-1.20.1.jar"
-      ],
-      "fileSize": 452304
-    },
-    {
-      "path": "mods/cloth-config-11.1.136-fabric.jar",
-      "hashes": {
-        "sha512": "2da85c071c854223cc30c8e46794391b77e53f28ecdbbde59dc83b3dbbdfc74be9e68da9ed464e7f98b4361033899ba4f681ebff1f35edc2c60e599a59796f1c",
-        "sha1": "d5fe84a0cc9ed5c7290a76ba570e1f8716afecab"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/9s6osm5g/versions/2xQdCMyG/cloth-config-11.1.136-fabric.jar"
-      ],
-      "fileSize": 1172214
-    },
-    {
-      "path": "mods/enhancedblockentities-0.9+1.20.jar",
-      "hashes": {
-        "sha512": "7e8b402fd25efd396bc7f0f25a663808ae9890accc227850c454dfcdc975657f22afceb15878e781485622434a6f6d60aff2a60264aa4425edd52ebe052a0de5",
-        "sha1": "61cfe50f69f8ef9e3640c0269ef158870f5b0410"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/OVuFYfre/versions/i3v1Skck/enhancedblockentities-0.9%2B1.20.jar"
-      ],
-      "fileSize": 490690
-    },
-    {
-      "path": "mods/c2me-fabric-mc1.20.1-0.2.0+alpha.11.16.jar",
-      "hashes": {
-        "sha1": "94d96b5fffd9e98bd8448dcdd9e27f60511b1d29",
-        "sha512": "359c715fd6a0464192d36b4d9dbb7927776eaae498f0cab939b49740fc724bda83aaf4f069f395dc5975d1e82762ee3b602111d9375eb27ab6f5360c4b17f2ff"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/VSNURh3q/versions/s4WOiNtz/c2me-fabric-mc1.20.1-0.2.0%2Balpha.11.16.jar"
-      ],
-      "fileSize": 1426500
-    },
-    {
-      "path": "mods/ferritecore-6.0.1-fabric.jar",
-      "hashes": {
-        "sha1": "8fa3b84fc5860dbc30fdf8cced02af68dffcf3fa",
-        "sha512": "9b7dc686bfa7937815d88c7bbc6908857cd6646b05e7a96ddbdcada328a385bd4ba056532cd1d7df9d2d7f4265fd48bd49ff683f217f6d4e817177b87f6bc457"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/uXXizFIs/versions/unerR5MN/ferritecore-6.0.1-fabric.jar"
-      ],
-      "fileSize": 125197
-    },
-    {
       "path": "mods/sodium-fabric-0.5.13+mc1.20.1.jar",
       "hashes": {
-        "sha512": "81c64f9c2d3402dfa43ee54d8f5a054f5243bfb08984e3addcab9fe885073c79c43c1c8c41e8f30b625d26a656f82a8e5f370bbbbf222ff1c08f4b324edb7ea4",
-        "sha1": "bcdbf37d9494e405cba210d7a80ed58e756297b5"
+        "sha1": "bcdbf37d9494e405cba210d7a80ed58e756297b5",
+        "sha512": "81c64f9c2d3402dfa43ee54d8f5a054f5243bfb08984e3addcab9fe885073c79c43c1c8c41e8f30b625d26a656f82a8e5f370bbbbf222ff1c08f4b324edb7ea4"
       },
       "env": {
         "client": "required",
@@ -171,14 +96,59 @@
       "fileSize": 971552
     },
     {
+      "path": "mods/c2me-fabric-mc1.20.1-0.2.0+alpha.11.16.jar",
+      "hashes": {
+        "sha512": "359c715fd6a0464192d36b4d9dbb7927776eaae498f0cab939b49740fc724bda83aaf4f069f395dc5975d1e82762ee3b602111d9375eb27ab6f5360c4b17f2ff",
+        "sha1": "94d96b5fffd9e98bd8448dcdd9e27f60511b1d29"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/VSNURh3q/versions/s4WOiNtz/c2me-fabric-mc1.20.1-0.2.0%2Balpha.11.16.jar"
+      ],
+      "fileSize": 1426500
+    },
+    {
+      "path": "mods/ImmediatelyFast-Fabric-1.5.1+1.20.4.jar",
+      "hashes": {
+        "sha512": "23ddba94cb88591a9381b16c1e8ac2f59a609407d4e3400c083f85d416c37d5a7c42c67d6908d92a98f84fdf93ad083b9c5e8a041a1d90b0ffcca573ab0d3d92",
+        "sha1": "4050cb966b7211c234494075769bc8baf33e3c31"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/5ZwdcRci/versions/zJD8Yaa3/ImmediatelyFast-Fabric-1.5.1%2B1.20.4.jar"
+      ],
+      "fileSize": 242574
+    },
+    {
+      "path": "mods/noisium-fabric-2.3.0+mc1.20-1.20.1.jar",
+      "hashes": {
+        "sha512": "f0abcdac514bd2b4eb6af3529eeb9980a6fef534d31244879acb291a9943151aeb34f372bf98ae01f6191870bf95e1c0bc36d522433353a1090b96e7ac03c417",
+        "sha1": "be85535cf1efe82bd8c41bcf851becaad498a598"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/KuNKN7d2/versions/erSJnRcq/noisium-fabric-2.3.0%2Bmc1.20-1.20.1.jar"
+      ],
+      "fileSize": 214902
+    },
+    {
       "path": "mods/lithium-fabric-mc1.20.1-0.11.3.jar",
       "hashes": {
         "sha512": "dc9bc65146f41cf99c46b46216dd3645be7c45cfeb2bc7cdceaa11bcd57771cdf2c30e84ce057f12b8dbf0d54fb808143cf46d92626370011ba5112bec18e720",
         "sha1": "7dc706d892b4c7cff0f7648e6b6256a64c3abec2"
       },
       "env": {
-        "server": "required",
-        "client": "required"
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/gvQqBUqZ/versions/vuuAe7ZA/lithium-fabric-mc1.20.1-0.11.3.jar"
@@ -186,14 +156,29 @@
       "fileSize": 706600
     },
     {
-      "path": "mods/moreculling-1.20.4-0.24.0.jar",
+      "path": "mods/ixeris-3.4.0+1.20.1-fabric.jar",
       "hashes": {
-        "sha1": "a40f2aa346140a4fee2079d845c62ee87454bdb6",
-        "sha512": "3a8accedfa48ce86b4091ce7994d63b2c7d1f6654119a5dc8430bd7370084bf04801c71600bb2b1546a58aef972797048f86eebbff2a666905a86c2b1cf7632e"
+        "sha1": "9808bd7c484a859ef8206c7b84a6435179c0c381",
+        "sha512": "04793bf2ee38c94d13ba3843fa139b4c225fe474f31f66c0d7583fb9942f198c3e4f944fa94b8978df8a75e757d021437e804c3001c0deb338675871e4e1a0dd"
       },
       "env": {
         "server": "required",
         "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/6W1bmIHf/ixeris-3.4.0%2B1.20.1-fabric.jar"
+      ],
+      "fileSize": 152331
+    },
+    {
+      "path": "mods/moreculling-1.20.4-0.24.0.jar",
+      "hashes": {
+        "sha512": "3a8accedfa48ce86b4091ce7994d63b2c7d1f6654119a5dc8430bd7370084bf04801c71600bb2b1546a58aef972797048f86eebbff2a666905a86c2b1cf7632e",
+        "sha1": "a40f2aa346140a4fee2079d845c62ee87454bdb6"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/51shyZVL/versions/3m5znPWm/moreculling-1.20.4-0.24.0.jar"
@@ -201,10 +186,25 @@
       "fileSize": 272851
     },
     {
+      "path": "mods/modernfix-fabric-5.24.4+mc1.20.1.jar",
+      "hashes": {
+        "sha1": "3d20fa94c463113a24346ed544f4ca95c54bae8d",
+        "sha512": "f56b3e3761af6031ecd4cab5b3dc143cbd47d97e0a5eb8138bd579bd6c169687d5affa154c71992703ffddb2e99f3e6c3852fb554ee0321467ffc6a8cc301a28"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/nmDcB62a/versions/PSpecC1r/modernfix-fabric-5.24.4%2Bmc1.20.1.jar"
+      ],
+      "fileSize": 533705
+    },
+    {
       "path": "mods/indium-1.0.36+mc1.20.1.jar",
       "hashes": {
-        "sha512": "7c5a1851f1fc08ae69318e151d07151fabba6cda2a24616c9251e1a4e5b969453e88b97d60f926271d60e3511bfc6fa05a64a108466efb7f29bec4519547e0c9",
-        "sha1": "d824614e7a173d273167969f427702f51846aca7"
+        "sha1": "d824614e7a173d273167969f427702f51846aca7",
+        "sha512": "7c5a1851f1fc08ae69318e151d07151fabba6cda2a24616c9251e1a4e5b969453e88b97d60f926271d60e3511bfc6fa05a64a108466efb7f29bec4519547e0c9"
       },
       "env": {
         "server": "required",
@@ -214,10 +214,25 @@
         "https://cdn.modrinth.com/data/Orvt0mRa/versions/nQHYSjxO/indium-1.0.36%2Bmc1.20.1.jar"
       ],
       "fileSize": 105382
+    },
+    {
+      "path": "mods/fabric-api-0.92.6+1.20.1.jar",
+      "hashes": {
+        "sha1": "3ec0a88b64f252257df6287e9a1d47ed96331e5d",
+        "sha512": "2bd2ed0cee22305b7ff49597c103a57c8fbe5f64be54a906796d48b589862626c951ff4cbf5cb1ed764a4d6479d69c3077594e693b7a291240eeea2bb3132b0c"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/P7dR8mSH/versions/UapVHwiP/fabric-api-0.92.6%2B1.20.1.jar"
+      ],
+      "fileSize": 2107873
     }
   ],
   "dependencies": {
-    "fabric-loader": "0.17.0",
-    "minecraft": "1.20.1"
+    "minecraft": "1.20.1",
+    "fabric-loader": "0.17.0"
   }
 }

--- a/Fabric/1.20.4/modrinth.index.json
+++ b/Fabric/1.20.4/modrinth.index.json
@@ -1,45 +1,30 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "1.0.7",
+  "versionId": "1.1.0",
   "name": "Photon",
   "summary": "",
   "files": [
     {
-      "path": "mods/c2me-fabric-mc1.20.4-0.2.0+alpha.11.72.jar",
+      "path": "mods/ixeris-3.4.0+1.20.4-fabric.jar",
       "hashes": {
-        "sha1": "cb60c6a25b5a77fd57f18bb1fd978bb13601c6d5",
-        "sha512": "bcc67b816ed01d67b5230d66f408223eb5c6d72f9fd500dab7c007a627d338491e0f1af4ba2929d35089ac9e22c9bc3a8eac48770c7c9aa7c78d70e453892ed1"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/VSNURh3q/versions/1AeveXNt/c2me-fabric-mc1.20.4-0.2.0%2Balpha.11.72.jar"
-      ],
-      "fileSize": 1289505
-    },
-    {
-      "path": "mods/enhancedblockentities-0.10.1+1.20.4.jar",
-      "hashes": {
-        "sha1": "f2b182c46486ecce3a2f84893efb1c1b9382e859",
-        "sha512": "36885e53d47764060a9fab5953f725c3fb82fa93285a6e5e01f44ffd4df105a9e2d9747ba15fe25462ce0b6909e99db447ef3ea5c0c1ea3a7007eec452adbb8f"
+        "sha1": "2df154508d805189639b7f6b00e89e3e607c6b32",
+        "sha512": "9e291109935601ea5415218590ae5887dcc9c4a73e14e49938bd3e53168bd7e7322fedd378cf520361aa564554c92e4b435f6af74c458e3705bd616969630089"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/OVuFYfre/versions/xUOoKrs2/enhancedblockentities-0.10.1%2B1.20.4.jar"
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/2QN84gzC/ixeris-3.4.0%2B1.20.4-fabric.jar"
       ],
-      "fileSize": 330603
+      "fileSize": 152384
     },
     {
       "path": "mods/sodium-fabric-0.5.8+mc1.20.4.jar",
       "hashes": {
-        "sha1": "4c38d7b01660a27a98406767c613b3f28b6c9dfe",
-        "sha512": "bd00b956bde1205171e744a6a3780e835fb6928eb667fb2b56467818c979fb1e8c82561380a71a7dbfa1516cd4b6cf9087ca99f1ae066da6d65af2c828b8d554"
+        "sha512": "bd00b956bde1205171e744a6a3780e835fb6928eb667fb2b56467818c979fb1e8c82561380a71a7dbfa1516cd4b6cf9087ca99f1ae066da6d65af2c828b8d554",
+        "sha1": "4c38d7b01660a27a98406767c613b3f28b6c9dfe"
       },
       "env": {
         "server": "required",
@@ -49,6 +34,36 @@
         "https://cdn.modrinth.com/data/AANobbMI/versions/4GyXKCLd/sodium-fabric-0.5.8%2Bmc1.20.4.jar"
       ],
       "fileSize": 949085
+    },
+    {
+      "path": "mods/lithium-fabric-mc1.20.4-0.12.1.jar",
+      "hashes": {
+        "sha512": "70bea154eaafb2e4b5cb755cdb12c55d50f9296ab4c2855399da548f72d6d24c0a9f77e3da2b2ea5f47fa91d1258df4d08c6c6f24a25da887ed71cea93502508",
+        "sha1": "4a0744beb2246d93cb475d21a5a53faa556956e0"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/nMhjKWVE/lithium-fabric-mc1.20.4-0.12.1.jar"
+      ],
+      "fileSize": 716022
+    },
+    {
+      "path": "mods/enhancedblockentities-0.10.1+1.20.4.jar",
+      "hashes": {
+        "sha512": "36885e53d47764060a9fab5953f725c3fb82fa93285a6e5e01f44ffd4df105a9e2d9747ba15fe25462ce0b6909e99db447ef3ea5c0c1ea3a7007eec452adbb8f",
+        "sha1": "f2b182c46486ecce3a2f84893efb1c1b9382e859"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/OVuFYfre/versions/xUOoKrs2/enhancedblockentities-0.10.1%2B1.20.4.jar"
+      ],
+      "fileSize": 330603
     },
     {
       "path": "mods/ImmediatelyFast-Fabric-1.5.1+1.20.4.jar",
@@ -66,34 +81,64 @@
       "fileSize": 242574
     },
     {
-      "path": "mods/noisium-fabric-2.3.0+mc1.20.2-1.20.4.jar",
+      "path": "mods/cloth-config-13.0.138-fabric.jar",
       "hashes": {
-        "sha1": "31be12110ac95503676adfaca2d9ac179e8b2072",
-        "sha512": "249cf90051e808a224a22b6d45812831793368297c5873512a25a7e5f4b866c3d2a625b04f74ed8d9987b6171e7cca085ed8d7a100336f395cc037f1493e0e2b"
+        "sha512": "3863fb95cc57526c6876cb60600f2e4282a5fa8d997d981e984da48f34be654cd0c5fc09e7d77079a393b2d7e3e48baabb756ad84ea58881b22ea771f43baa4a",
+        "sha1": "e374f80329cea3d73e10e31839fe79d5a4fc0b30"
       },
       "env": {
-        "client": "required",
-        "server": "required"
+        "server": "required",
+        "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/KuNKN7d2/versions/RmNpWBtf/noisium-fabric-2.3.0%2Bmc1.20.2-1.20.4.jar"
+        "https://cdn.modrinth.com/data/9s6osm5g/versions/2deYQULk/cloth-config-13.0.138-fabric.jar"
       ],
-      "fileSize": 214908
+      "fileSize": 1154870
     },
     {
-      "path": "mods/indium-1.0.31+mc1.20.4.jar",
+      "path": "mods/BadOptimizations-2.3.0-1.20.2-20.4.jar",
       "hashes": {
-        "sha512": "27b4a73ca990742e27eee4348553c86c96c19fddcd0763892029f67ddbde42dc03c0ac21230403ae6b4ce4da315d0d49f582d3daab413b9ea84fd6d172ee7c4f",
-        "sha1": "fe6d0513ac332d890f1bd9bb9354a8e240b8f0e5"
+        "sha512": "7e544e5b18ee1b276906f74a65ebfcca4f34b8b1721246dbf0644ed1c76f18f267f1475ba553732255496f41cfd2febf52b9da9181657b53e0b9919340fa5b18",
+        "sha1": "70cfad11ea5b8a9b6001d815199f548104fd9d12"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/irRJRJN4/BadOptimizations-2.3.0-1.20.2-20.4.jar"
+      ],
+      "fileSize": 147469
+    },
+    {
+      "path": "mods/c2me-fabric-mc1.20.4-0.2.0+alpha.11.72.jar",
+      "hashes": {
+        "sha1": "cb60c6a25b5a77fd57f18bb1fd978bb13601c6d5",
+        "sha512": "bcc67b816ed01d67b5230d66f408223eb5c6d72f9fd500dab7c007a627d338491e0f1af4ba2929d35089ac9e22c9bc3a8eac48770c7c9aa7c78d70e453892ed1"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/Orvt0mRa/versions/VlLxDisa/indium-1.0.31%2Bmc1.20.4.jar"
+        "https://cdn.modrinth.com/data/VSNURh3q/versions/1AeveXNt/c2me-fabric-mc1.20.4-0.2.0%2Balpha.11.72.jar"
       ],
-      "fileSize": 105350
+      "fileSize": 1289505
+    },
+    {
+      "path": "mods/modernfix-fabric-5.17.0+mc1.20.4.jar",
+      "hashes": {
+        "sha1": "cf5f1f0db74b0385c2738c6fbf8347e7e68100d6",
+        "sha512": "8404bc285100746ac76467094b2b4feb132e046272780c4c8a6d4bd4336fad70073734438e9f37bf7e46ffa65dbf2f06ab10232b09c3911c08215dfcf71fca0e"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/nmDcB62a/versions/CV2Vtn5m/modernfix-fabric-5.17.0%2Bmc1.20.4.jar"
+      ],
+      "fileSize": 458056
     },
     {
       "path": "mods/entityculling-fabric-1.8.2-mc1.20.4.jar",
@@ -102,28 +147,13 @@
         "sha512": "1951e3a233837cb00cd1ea49bcbb8576bb991b6a4c70f776fc3d1756c7bbdefc7a796f292581c417a5c9a84951c735cf767ab7d082a0f89252d5727ff07b8e23"
       },
       "env": {
-        "server": "required",
-        "client": "required"
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/NNAgCjsB/versions/fV7BWjfG/entityculling-fabric-1.8.2-mc1.20.4.jar"
       ],
       "fileSize": 470518
-    },
-    {
-      "path": "mods/lithium-fabric-mc1.20.4-0.12.1.jar",
-      "hashes": {
-        "sha1": "4a0744beb2246d93cb475d21a5a53faa556956e0",
-        "sha512": "70bea154eaafb2e4b5cb755cdb12c55d50f9296ab4c2855399da548f72d6d24c0a9f77e3da2b2ea5f47fa91d1258df4d08c6c6f24a25da887ed71cea93502508"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/nMhjKWVE/lithium-fabric-mc1.20.4-0.12.1.jar"
-      ],
-      "fileSize": 716022
     },
     {
       "path": "mods/ferritecore-6.0.3-fabric.jar",
@@ -132,43 +162,13 @@
         "sha1": "f2bbb773f4213d36201b76820f206e2a6f213c0c"
       },
       "env": {
-        "client": "required",
-        "server": "required"
+        "server": "required",
+        "client": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/uXXizFIs/versions/pguEMpy9/ferritecore-6.0.3-fabric.jar"
       ],
       "fileSize": 125100
-    },
-    {
-      "path": "mods/fabric-api-0.97.3+1.20.4.jar",
-      "hashes": {
-        "sha512": "ea1e47672a1e0fef7fa3fd7f7b396b5a8fb2c46e6ce33dbc4cc2b8d320bc7b775a0de42a478302419c8063c47fbc18bb2ad7551772f54af8059132ac2cb4f108",
-        "sha1": "a21f3c7e700b9fc3a28e896979a07ec489507143"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/P7dR8mSH/versions/BPX6fK06/fabric-api-0.97.3%2B1.20.4.jar"
-      ],
-      "fileSize": 2187523
-    },
-    {
-      "path": "mods/cloth-config-13.0.138-fabric.jar",
-      "hashes": {
-        "sha512": "3863fb95cc57526c6876cb60600f2e4282a5fa8d997d981e984da48f34be654cd0c5fc09e7d77079a393b2d7e3e48baabb756ad84ea58881b22ea771f43baa4a",
-        "sha1": "e374f80329cea3d73e10e31839fe79d5a4fc0b30"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/9s6osm5g/versions/2deYQULk/cloth-config-13.0.138-fabric.jar"
-      ],
-      "fileSize": 1154870
     },
     {
       "path": "mods/moreculling-1.20.4-0.24.0.jar",
@@ -186,38 +186,53 @@
       "fileSize": 272851
     },
     {
-      "path": "mods/BadOptimizations-2.3.0-1.20.2-20.4.jar",
+      "path": "mods/indium-1.0.31+mc1.20.4.jar",
       "hashes": {
-        "sha1": "70cfad11ea5b8a9b6001d815199f548104fd9d12",
-        "sha512": "7e544e5b18ee1b276906f74a65ebfcca4f34b8b1721246dbf0644ed1c76f18f267f1475ba553732255496f41cfd2febf52b9da9181657b53e0b9919340fa5b18"
+        "sha512": "27b4a73ca990742e27eee4348553c86c96c19fddcd0763892029f67ddbde42dc03c0ac21230403ae6b4ce4da315d0d49f582d3daab413b9ea84fd6d172ee7c4f",
+        "sha1": "fe6d0513ac332d890f1bd9bb9354a8e240b8f0e5"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/irRJRJN4/BadOptimizations-2.3.0-1.20.2-20.4.jar"
+        "https://cdn.modrinth.com/data/Orvt0mRa/versions/VlLxDisa/indium-1.0.31%2Bmc1.20.4.jar"
       ],
-      "fileSize": 147469
+      "fileSize": 105350
     },
     {
-      "path": "mods/modernfix-fabric-5.17.0+mc1.20.4.jar",
+      "path": "mods/noisium-fabric-2.3.0+mc1.20.2-1.20.4.jar",
       "hashes": {
-        "sha1": "cf5f1f0db74b0385c2738c6fbf8347e7e68100d6",
-        "sha512": "8404bc285100746ac76467094b2b4feb132e046272780c4c8a6d4bd4336fad70073734438e9f37bf7e46ffa65dbf2f06ab10232b09c3911c08215dfcf71fca0e"
+        "sha1": "31be12110ac95503676adfaca2d9ac179e8b2072",
+        "sha512": "249cf90051e808a224a22b6d45812831793368297c5873512a25a7e5f4b866c3d2a625b04f74ed8d9987b6171e7cca085ed8d7a100336f395cc037f1493e0e2b"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/KuNKN7d2/versions/RmNpWBtf/noisium-fabric-2.3.0%2Bmc1.20.2-1.20.4.jar"
+      ],
+      "fileSize": 214908
+    },
+    {
+      "path": "mods/fabric-api-0.97.3+1.20.4.jar",
+      "hashes": {
+        "sha1": "a21f3c7e700b9fc3a28e896979a07ec489507143",
+        "sha512": "ea1e47672a1e0fef7fa3fd7f7b396b5a8fb2c46e6ce33dbc4cc2b8d320bc7b775a0de42a478302419c8063c47fbc18bb2ad7551772f54af8059132ac2cb4f108"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/nmDcB62a/versions/CV2Vtn5m/modernfix-fabric-5.17.0%2Bmc1.20.4.jar"
+        "https://cdn.modrinth.com/data/P7dR8mSH/versions/BPX6fK06/fabric-api-0.97.3%2B1.20.4.jar"
       ],
-      "fileSize": 458056
+      "fileSize": 2187523
     }
   ],
   "dependencies": {
-    "fabric-loader": "0.17.0",
-    "minecraft": "1.20.4"
+    "minecraft": "1.20.4",
+    "fabric-loader": "0.17.0"
   }
 }

--- a/Fabric/1.21.1/modrinth.index.json
+++ b/Fabric/1.21.1/modrinth.index.json
@@ -1,15 +1,45 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "1.0.19",
+  "versionId": "1.1.0",
   "name": "Photon",
   "summary": "",
   "files": [
     {
+      "path": "mods/moreculling-fabric-1.21.1-1.0.6.jar",
+      "hashes": {
+        "sha1": "e14150baf443abc24ee6236b837c287dd5950e95",
+        "sha512": "c6a6db1e2b63084457358171175ddf6061b32d31843f982001720c34433ae96cb13d72b910dc486ad1556e9db55352df3619f131c733bf843d3273d248989b05"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/51shyZVL/versions/1V6UtDhN/moreculling-fabric-1.21.1-1.0.6.jar"
+      ],
+      "fileSize": 345544
+    },
+    {
+      "path": "mods/sodium-fabric-0.6.13+mc1.21.1.jar",
+      "hashes": {
+        "sha512": "13032e064c554fc8671573dadb07bc70e6ea2f68706c65c086c4feb1d2f664346a3414cbf9d1367b42b8d063a35e40f2f967ef9af31642e1f0093b852161fe91",
+        "sha1": "928a2598178c3a58b0638bab842f467d2e49251a"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/AANobbMI/versions/u1OEbNKx/sodium-fabric-0.6.13%2Bmc1.21.1.jar"
+      ],
+      "fileSize": 1297761
+    },
+    {
       "path": "mods/noisium-fabric-2.3.0+mc1.21-1.21.1.jar",
       "hashes": {
-        "sha512": "606ba78cf7f30d99e417c96aa042f600c1b626ed9c783919496d139de650013f1434fcf93545782e3889660322837ce6e85530d9e1a5cc20f9ad161357ede43e",
-        "sha1": "642a672cfc60ff1e1262a39d7e160b1381c5120c"
+        "sha1": "642a672cfc60ff1e1262a39d7e160b1381c5120c",
+        "sha512": "606ba78cf7f30d99e417c96aa042f600c1b626ed9c783919496d139de650013f1434fcf93545782e3889660322837ce6e85530d9e1a5cc20f9ad161357ede43e"
       },
       "env": {
         "server": "required",
@@ -23,8 +53,8 @@
     {
       "path": "mods/c2me-fabric-mc1.21.1-0.3.0+alpha.0.320.jar",
       "hashes": {
-        "sha1": "fe53bfdccad85f039de2d1d04f0791caf91e12c8",
-        "sha512": "5ae8ff5e2d6b849aee1e71ee5ec22f68c3713617b9e246de7fdfea8af8d7a84d63f2cb13ed0949dfb119c7d647295244b476d34c618baf3bed171e33fc3872d6"
+        "sha512": "5ae8ff5e2d6b849aee1e71ee5ec22f68c3713617b9e246de7fdfea8af8d7a84d63f2cb13ed0949dfb119c7d647295244b476d34c618baf3bed171e33fc3872d6",
+        "sha1": "fe53bfdccad85f039de2d1d04f0791caf91e12c8"
       },
       "env": {
         "client": "required",
@@ -36,29 +66,14 @@
       "fileSize": 4667083
     },
     {
-      "path": "mods/enhancedblockentities-0.10.2+1.21.jar",
-      "hashes": {
-        "sha512": "60e01db603fcf1392c0cd5c3ce742e568f7d445d83fe60828b21f546e7d29fb6947231f22d28e29b07f4bdcb767b6dc2a2398b4decea665ecba1166690a44d49",
-        "sha1": "d81359d77fc7c5437f3e83e519dc2f869300f0cd"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/OVuFYfre/versions/HBZAPs3u/enhancedblockentities-0.10.2%2B1.21.jar"
-      ],
-      "fileSize": 201157
-    },
-    {
       "path": "mods/BadOptimizations-2.3.0-1.21.1.jar",
       "hashes": {
         "sha512": "a9d78ab8d84d0ba3ebfd77eb3c4f585b9c3f0cad8e59b0ecef8c3ba107067342d7549f275c8fe45a5d4f35f7d848a15c184ad6e369044e659d17ce08afe91a77",
         "sha1": "0d759c0996fbfc1ed4066170351722e6d9e52884"
       },
       "env": {
-        "server": "required",
-        "client": "required"
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/g96Z4WVZ/versions/AQrpXs3f/BadOptimizations-2.3.0-1.21.1.jar"
@@ -66,109 +81,19 @@
       "fileSize": 123862
     },
     {
-      "path": "mods/sodium-fabric-0.6.13+mc1.21.1.jar",
+      "path": "mods/enhancedblockentities-0.10.2+1.21.jar",
       "hashes": {
-        "sha512": "13032e064c554fc8671573dadb07bc70e6ea2f68706c65c086c4feb1d2f664346a3414cbf9d1367b42b8d063a35e40f2f967ef9af31642e1f0093b852161fe91",
-        "sha1": "928a2598178c3a58b0638bab842f467d2e49251a"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/AANobbMI/versions/u1OEbNKx/sodium-fabric-0.6.13%2Bmc1.21.1.jar"
-      ],
-      "fileSize": 1297761
-    },
-    {
-      "path": "mods/lithium-fabric-0.15.0+mc1.21.1.jar",
-      "hashes": {
-        "sha1": "b7d77602807f2c7cd7132741244bf8c0b8dec6c1",
-        "sha512": "fd3215501ebe8f6590cdf1ccc58182873cad8d74ebc4b0b3a2f5724748b9cb04c2b967503c072311dfbca9ba856195dc4662f3395a071b294fa0acfdd2a86bf6"
+        "sha1": "d81359d77fc7c5437f3e83e519dc2f869300f0cd",
+        "sha512": "60e01db603fcf1392c0cd5c3ce742e568f7d445d83fe60828b21f546e7d29fb6947231f22d28e29b07f4bdcb767b6dc2a2398b4decea665ecba1166690a44d49"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/MM5BBBOK/lithium-fabric-0.15.0%2Bmc1.21.1.jar"
+        "https://cdn.modrinth.com/data/OVuFYfre/versions/HBZAPs3u/enhancedblockentities-0.10.2%2B1.21.jar"
       ],
-      "fileSize": 771768
-    },
-    {
-      "path": "mods/ferritecore-7.0.2-hotfix-fabric.jar",
-      "hashes": {
-        "sha512": "ca975bd3708cd96d30cf1447ac8883572113562eb2dd697e60c1cf382d6b70d0b1a511fcbfd042c51b2cf5d5ffc718b847f845e4c8a3e421e8c9ee741119a421",
-        "sha1": "48ee764932d0c8ec81a2223dbe333886938e512c"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/uXXizFIs/versions/bwKMSBhn/ferritecore-7.0.2-hotfix-fabric.jar"
-      ],
-      "fileSize": 120709
-    },
-    {
-      "path": "mods/moreculling-fabric-1.21.1-1.0.6.jar",
-      "hashes": {
-        "sha512": "c6a6db1e2b63084457358171175ddf6061b32d31843f982001720c34433ae96cb13d72b910dc486ad1556e9db55352df3619f131c733bf843d3273d248989b05",
-        "sha1": "e14150baf443abc24ee6236b837c287dd5950e95"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/51shyZVL/versions/1V6UtDhN/moreculling-fabric-1.21.1-1.0.6.jar"
-      ],
-      "fileSize": 345544
-    },
-    {
-      "path": "mods/modernfix-fabric-5.24.3+mc1.21.1.jar",
-      "hashes": {
-        "sha1": "fd5bd05c9380243b3fa86e42b3649d8cdb235a60",
-        "sha512": "43a81e63638387701edc49aabbde9e293890165e6e3b2df378aeabf56ea41fd666c1841cfac488e8d723ee99a673e09de4cc37a3e2141e04216f4aad5254dae1"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/nmDcB62a/versions/xDJFoW9U/modernfix-fabric-5.24.3%2Bmc1.21.1.jar"
-      ],
-      "fileSize": 460259
-    },
-    {
-      "path": "mods/cloth-config-15.0.140-fabric.jar",
-      "hashes": {
-        "sha1": "5d82342a2df53fd6df712bfdd583a811572918a4",
-        "sha512": "1b3f5db4fc1d481704053db9837d530919374bf7518d7cede607360f0348c04fc6347a3a72ccfef355559e1f4aef0b650cd58e5ee79c73b12ff0fc2746797a00"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/9s6osm5g/versions/HpMb5wGb/cloth-config-15.0.140-fabric.jar"
-      ],
-      "fileSize": 1157166
-    },
-    {
-      "path": "mods/ImmediatelyFast-Fabric-1.6.6+1.21.1.jar",
-      "hashes": {
-        "sha1": "8929468087041b6b07b65aa8e31407f5c9e43b79",
-        "sha512": "7855cbfc71f24d5a6a09211061bc0a88c2b7c597bb38850e6c8c15796ad0ad1daf5c1c7b1cf519124e97ab0ef1241cb2e9509a9b4f998aa18c7a2588a9b1eca7"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/5ZwdcRci/versions/giRXGeHH/ImmediatelyFast-Fabric-1.6.6%2B1.21.1.jar"
-      ],
-      "fileSize": 228315
+      "fileSize": 201157
     },
     {
       "path": "mods/entityculling-fabric-1.8.2-mc1.21.jar",
@@ -186,6 +111,36 @@
       "fileSize": 469193
     },
     {
+      "path": "mods/ixeris-3.4.0+1.21.1-fabric.jar",
+      "hashes": {
+        "sha1": "b14de0084816dc86fb5dc2d2c9891c15849a5025",
+        "sha512": "f59d92a743998e0f59c9b8fd160dd3be6d5c210c073f0b02211b3c2a4358a850792970a1d426ce2319d18ab67de084802c4a7d61cca1c4f1555b1e893d196e0a"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/7fPcPGnb/ixeris-3.4.0%2B1.21.1-fabric.jar"
+      ],
+      "fileSize": 152349
+    },
+    {
+      "path": "mods/cloth-config-15.0.140-fabric.jar",
+      "hashes": {
+        "sha1": "5d82342a2df53fd6df712bfdd583a811572918a4",
+        "sha512": "1b3f5db4fc1d481704053db9837d530919374bf7518d7cede607360f0348c04fc6347a3a72ccfef355559e1f4aef0b650cd58e5ee79c73b12ff0fc2746797a00"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/9s6osm5g/versions/HpMb5wGb/cloth-config-15.0.140-fabric.jar"
+      ],
+      "fileSize": 1157166
+    },
+    {
       "path": "mods/fabric-api-0.116.4+1.21.1.jar",
       "hashes": {
         "sha512": "95060def77b54ba6c6eb5af45b478ec6926f33f145d8f3933cd90cb2b6ab6913459d3d0afa3afcb01fca07d714628414a41ee8b6845261e88d92b83bfc668ad8",
@@ -199,10 +154,70 @@
         "https://cdn.modrinth.com/data/P7dR8mSH/versions/19viawBV/fabric-api-0.116.4%2B1.21.1.jar"
       ],
       "fileSize": 2423497
+    },
+    {
+      "path": "mods/lithium-fabric-0.15.0+mc1.21.1.jar",
+      "hashes": {
+        "sha512": "fd3215501ebe8f6590cdf1ccc58182873cad8d74ebc4b0b3a2f5724748b9cb04c2b967503c072311dfbca9ba856195dc4662f3395a071b294fa0acfdd2a86bf6",
+        "sha1": "b7d77602807f2c7cd7132741244bf8c0b8dec6c1"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/MM5BBBOK/lithium-fabric-0.15.0%2Bmc1.21.1.jar"
+      ],
+      "fileSize": 771768
+    },
+    {
+      "path": "mods/ImmediatelyFast-Fabric-1.6.6+1.21.1.jar",
+      "hashes": {
+        "sha512": "7855cbfc71f24d5a6a09211061bc0a88c2b7c597bb38850e6c8c15796ad0ad1daf5c1c7b1cf519124e97ab0ef1241cb2e9509a9b4f998aa18c7a2588a9b1eca7",
+        "sha1": "8929468087041b6b07b65aa8e31407f5c9e43b79"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/5ZwdcRci/versions/giRXGeHH/ImmediatelyFast-Fabric-1.6.6%2B1.21.1.jar"
+      ],
+      "fileSize": 228315
+    },
+    {
+      "path": "mods/modernfix-fabric-5.24.3+mc1.21.1.jar",
+      "hashes": {
+        "sha512": "43a81e63638387701edc49aabbde9e293890165e6e3b2df378aeabf56ea41fd666c1841cfac488e8d723ee99a673e09de4cc37a3e2141e04216f4aad5254dae1",
+        "sha1": "fd5bd05c9380243b3fa86e42b3649d8cdb235a60"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/nmDcB62a/versions/xDJFoW9U/modernfix-fabric-5.24.3%2Bmc1.21.1.jar"
+      ],
+      "fileSize": 460259
+    },
+    {
+      "path": "mods/ferritecore-7.0.2-hotfix-fabric.jar",
+      "hashes": {
+        "sha512": "ca975bd3708cd96d30cf1447ac8883572113562eb2dd697e60c1cf382d6b70d0b1a511fcbfd042c51b2cf5d5ffc718b847f845e4c8a3e421e8c9ee741119a421",
+        "sha1": "48ee764932d0c8ec81a2223dbe333886938e512c"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/uXXizFIs/versions/bwKMSBhn/ferritecore-7.0.2-hotfix-fabric.jar"
+      ],
+      "fileSize": 120709
     }
   ],
   "dependencies": {
     "minecraft": "1.21.1",
-    "fabric-loader": "0.16.14"
+    "fabric-loader": "0.17.0"
   }
 }

--- a/Fabric/1.21.8/modrinth.index.json
+++ b/Fabric/1.21.8/modrinth.index.json
@@ -1,49 +1,34 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "0.1.2",
+  "versionId": "0.2.0",
   "name": "Photon",
   "summary": "",
   "files": [
     {
-      "path": "mods/fabric-api-0.130.0+1.21.8.jar",
+      "path": "mods/c2me-fabric-mc1.21.8-0.3.4.0.0.jar",
       "hashes": {
-        "sha1": "5d8c74464535d569991dcdacf9bb61203c6cd73a",
-        "sha512": "27399d629d3fb955c8fc1e5e86cacb9b124814bb97ee7fe283336b0e28f5eb9ae31619814ab4aef70c5beea908d2a1ed5a8dd6b8641a53ecd50375d50067f061"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/P7dR8mSH/versions/zhzhM2yQ/fabric-api-0.130.0%2B1.21.8.jar"
-      ],
-      "fileSize": 2212919
-    },
-    {
-      "path": "mods/sodium-fabric-0.6.13+mc1.21.6.jar",
-      "hashes": {
-        "sha1": "2d635c3d938aa3f75b0ec61c7402eeea2f9c30a9",
-        "sha512": "ee97e3df07a6f734bc8a0f77c1f1de7f47bed09cf682f048ceb12675c51b70ba727b11fcacbb7b10cc9f79b283dd71a39751312b5c70568aa3ac9471407174db"
+        "sha512": "30cbc520cb8349036d55a1cb1f26964cf02410cf6d6a561d9cc07164d7566a3a7564367de62510f2bab50723c2c7c401718001153fa833560634ce4b2e212767",
+        "sha1": "0951ad76de856b2e8804f06efc4302f828dc3bff"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/AANobbMI/versions/ND4ROcMQ/sodium-fabric-0.6.13%2Bmc1.21.6.jar"
+        "https://cdn.modrinth.com/data/VSNURh3q/versions/tlZRTK1v/c2me-fabric-mc1.21.8-0.3.4.0.0.jar"
       ],
-      "fileSize": 1443665
+      "fileSize": 4681084
     },
     {
       "path": "mods/moreculling-fabric-1.21.6-1.4.0-beta.1.jar",
       "hashes": {
-        "sha1": "1e9b9ec184470aa5d52e0d968b5e87cf087efae2",
-        "sha512": "0f80c58b539c55c0b96a35b685694d8d74bf77f5dd9c63a7f811c17cf076ae26799b6411e941ff71d2f39b940262886fb3d66f78f239b7bb3558cce8c5447dac"
+        "sha512": "0f80c58b539c55c0b96a35b685694d8d74bf77f5dd9c63a7f811c17cf076ae26799b6411e941ff71d2f39b940262886fb3d66f78f239b7bb3558cce8c5447dac",
+        "sha1": "1e9b9ec184470aa5d52e0d968b5e87cf087efae2"
       },
       "env": {
-        "client": "required",
-        "server": "required"
+        "server": "required",
+        "client": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/51shyZVL/versions/ESxkwc6w/moreculling-fabric-1.21.6-1.4.0-beta.1.jar"
@@ -51,85 +36,10 @@
       "fileSize": 347230
     },
     {
-      "path": "mods/entityculling-fabric-1.8.2-mc1.21.6.jar",
-      "hashes": {
-        "sha1": "56c5a0617863c53cf7e338d6ff862d02801a1f75",
-        "sha512": "528236d3d68ab4338dd0e1b3016a2381c6f341fb2b0854f93013c968710d9263f118a226abf422a6f43bb9ff7252833abf228f82dc47a099d83cf7848c55b9a7"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/NNAgCjsB/versions/5wVZFo2d/entityculling-fabric-1.8.2-mc1.21.6.jar"
-      ],
-      "fileSize": 473028
-    },
-    {
-      "path": "mods/noisium-fabric-2.7.0+mc1.21.6.jar",
-      "hashes": {
-        "sha512": "80cc286f3a51b2d12304ef6a44f84c11d67cedec1a02fbaf59e2e816d9b5f0abd17cc6b5a0ca5880935e9dadfea3b951b790ee1e54300c009bc419c1c7451785",
-        "sha1": "e0a53dd0ccd5d1bc13798214e16f9f8a8521a335"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/KuNKN7d2/versions/V9mMIy0f/noisium-fabric-2.7.0%2Bmc1.21.6.jar"
-      ],
-      "fileSize": 216078
-    },
-    {
-      "path": "mods/cloth-config-19.0.147-fabric.jar",
-      "hashes": {
-        "sha512": "924b7e9bf6da670b936c3eaf3a2ba7904a05eff4fd712acf8ee62e587770c05a225109d3c0bdf015992e870945d2086aa00e738f90b3b109e364b0105c08875a",
-        "sha1": "d3bd78860580da556990726af3bed1169e69933e"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/9s6osm5g/versions/cz0b1j8R/cloth-config-19.0.147-fabric.jar"
-      ],
-      "fileSize": 1149126
-    },
-    {
-      "path": "mods/BadOptimizations-2.3.0-1.21.6-21.7.jar",
-      "hashes": {
-        "sha512": "5d61b7c0946bef98bcda081f96d083bc6ae9c96e0de1ffe388406d9668a8878b2c3342465caa86270c9f33a6e00c42d5145718f8ce4a387025c2818581bdb6ce",
-        "sha1": "6ca1457a183266af76099c382b926f56c7e5d007"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/Zkvk6pH6/BadOptimizations-2.3.0-1.21.6-21.7.jar"
-      ],
-      "fileSize": 123961
-    },
-    {
-      "path": "mods/ferritecore-8.0.0-fabric.jar",
-      "hashes": {
-        "sha1": "53d76354587cd1965b842fdce7cff965b5c52fe5",
-        "sha512": "131b82d1d366f0966435bfcb38c362d604d68ecf30c106d31a6261bfc868ca3a82425bb3faebaa2e5ea17d8eed5c92843810eb2df4790f2f8b1e6c1bdc9b7745"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/uXXizFIs/versions/CtMpt7Jr/ferritecore-8.0.0-fabric.jar"
-      ],
-      "fileSize": 79653
-    },
-    {
       "path": "mods/ImmediatelyFast-Fabric-1.12.1+1.21.8.jar",
       "hashes": {
-        "sha512": "5277ba33c2f8255c65946a9e785a046d1c211aa974e679d881b9a259a50f42fc5f77a92d620a377d5992c66fa1ca581bb2fd902d1f93cdced4318fc2b10e45a8",
-        "sha1": "318608e466371772a4b0d2a6cd3fe86cf983e718"
+        "sha1": "318608e466371772a4b0d2a6cd3fe86cf983e718",
+        "sha512": "5277ba33c2f8255c65946a9e785a046d1c211aa974e679d881b9a259a50f42fc5f77a92d620a377d5992c66fa1ca581bb2fd902d1f93cdced4318fc2b10e45a8"
       },
       "env": {
         "server": "required",
@@ -139,6 +49,111 @@
         "https://cdn.modrinth.com/data/5ZwdcRci/versions/XxwOC2sk/ImmediatelyFast-Fabric-1.12.1%2B1.21.8.jar"
       ],
       "fileSize": 194728
+    },
+    {
+      "path": "mods/ferritecore-8.0.0-fabric.jar",
+      "hashes": {
+        "sha1": "53d76354587cd1965b842fdce7cff965b5c52fe5",
+        "sha512": "131b82d1d366f0966435bfcb38c362d604d68ecf30c106d31a6261bfc868ca3a82425bb3faebaa2e5ea17d8eed5c92843810eb2df4790f2f8b1e6c1bdc9b7745"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/uXXizFIs/versions/CtMpt7Jr/ferritecore-8.0.0-fabric.jar"
+      ],
+      "fileSize": 79653
+    },
+    {
+      "path": "mods/sodium-fabric-0.6.13+mc1.21.6.jar",
+      "hashes": {
+        "sha512": "ee97e3df07a6f734bc8a0f77c1f1de7f47bed09cf682f048ceb12675c51b70ba727b11fcacbb7b10cc9f79b283dd71a39751312b5c70568aa3ac9471407174db",
+        "sha1": "2d635c3d938aa3f75b0ec61c7402eeea2f9c30a9"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/AANobbMI/versions/ND4ROcMQ/sodium-fabric-0.6.13%2Bmc1.21.6.jar"
+      ],
+      "fileSize": 1443665
+    },
+    {
+      "path": "mods/fabric-api-0.131.0+1.21.8.jar",
+      "hashes": {
+        "sha512": "a4c7030d16eb012745b1ff3cb5487b08b88500259f5269a87815868ee686c02d5ba93cf2645de0f023f74c7cd78415c5be8938ce3d8fff24ccb1219ebb7a3a2b",
+        "sha1": "c76a1cd624d8ad517f307ad0fc8484c4b3eabe97"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/P7dR8mSH/versions/ax9iQEs0/fabric-api-0.131.0%2B1.21.8.jar"
+      ],
+      "fileSize": 2224100
+    },
+    {
+      "path": "mods/cloth-config-19.0.147-fabric.jar",
+      "hashes": {
+        "sha512": "924b7e9bf6da670b936c3eaf3a2ba7904a05eff4fd712acf8ee62e587770c05a225109d3c0bdf015992e870945d2086aa00e738f90b3b109e364b0105c08875a",
+        "sha1": "d3bd78860580da556990726af3bed1169e69933e"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/9s6osm5g/versions/cz0b1j8R/cloth-config-19.0.147-fabric.jar"
+      ],
+      "fileSize": 1149126
+    },
+    {
+      "path": "mods/noisium-fabric-2.7.0+mc1.21.6.jar",
+      "hashes": {
+        "sha512": "80cc286f3a51b2d12304ef6a44f84c11d67cedec1a02fbaf59e2e816d9b5f0abd17cc6b5a0ca5880935e9dadfea3b951b790ee1e54300c009bc419c1c7451785",
+        "sha1": "e0a53dd0ccd5d1bc13798214e16f9f8a8521a335"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/KuNKN7d2/versions/V9mMIy0f/noisium-fabric-2.7.0%2Bmc1.21.6.jar"
+      ],
+      "fileSize": 216078
+    },
+    {
+      "path": "mods/entityculling-fabric-1.8.2-mc1.21.6.jar",
+      "hashes": {
+        "sha512": "528236d3d68ab4338dd0e1b3016a2381c6f341fb2b0854f93013c968710d9263f118a226abf422a6f43bb9ff7252833abf228f82dc47a099d83cf7848c55b9a7",
+        "sha1": "56c5a0617863c53cf7e338d6ff862d02801a1f75"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/NNAgCjsB/versions/5wVZFo2d/entityculling-fabric-1.8.2-mc1.21.6.jar"
+      ],
+      "fileSize": 473028
+    },
+    {
+      "path": "mods/ixeris-3.4.0+1.21.8-fabric.jar",
+      "hashes": {
+        "sha512": "cbedb022aea74831a53df5b468009d1c1b0bdb3e0d426a73f3f0570acfe7c9bf9c2d172e47fff35d23f4ef84ec6c58bc0455238ff6fb5a59fe6f4a6182088172",
+        "sha1": "3f8cf2bed81858b647c5546f3bfff6bef45e951b"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/wOsMJPaE/ixeris-3.4.0%2B1.21.8-fabric.jar"
+      ],
+      "fileSize": 152330
     },
     {
       "path": "mods/lithium-fabric-0.18.0+mc1.21.8.jar",
@@ -156,19 +171,19 @@
       "fileSize": 792413
     },
     {
-      "path": "mods/c2me-fabric-mc1.21.8-0.3.4.0.0.jar",
+      "path": "mods/BadOptimizations-2.3.0-1.21.6-21.7.jar",
       "hashes": {
-        "sha1": "0951ad76de856b2e8804f06efc4302f828dc3bff",
-        "sha512": "30cbc520cb8349036d55a1cb1f26964cf02410cf6d6a561d9cc07164d7566a3a7564367de62510f2bab50723c2c7c401718001153fa833560634ce4b2e212767"
+        "sha512": "5d61b7c0946bef98bcda081f96d083bc6ae9c96e0de1ffe388406d9668a8878b2c3342465caa86270c9f33a6e00c42d5145718f8ce4a387025c2818581bdb6ce",
+        "sha1": "6ca1457a183266af76099c382b926f56c7e5d007"
       },
       "env": {
-        "server": "required",
-        "client": "required"
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/VSNURh3q/versions/tlZRTK1v/c2me-fabric-mc1.21.8-0.3.4.0.0.jar"
+        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/Zkvk6pH6/BadOptimizations-2.3.0-1.21.6-21.7.jar"
       ],
-      "fileSize": 4681084
+      "fileSize": 123961
     }
   ],
   "dependencies": {

--- a/MODLIST.md
+++ b/MODLIST.md
@@ -18,6 +18,7 @@
             <li><a href="https://modrinth.com/mod/fabric-api">Fabric API</a> by <a href="https://modrinth.com/user/modmuss50">modmuss50</a></li>
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
+            <li><a href="https://modrinth.com/mod/ixeris">Ixeris</a> by <a href="https://modrinth.com/user/decce6">decce6</a></li>
             <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
             <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>
             <li><a href="https://modrinth.com/mod/noisium">Noisium</a> by <a href="https://modrinth.com/user/Steveplays">Steveplays</a></li>
@@ -101,6 +102,7 @@
             <li><a href="https://modrinth.com/mod/fabric-api">Fabric API</a> by <a href="https://modrinth.com/user/modmuss50">modmuss50</a></li>
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
+            <li><a href="https://modrinth.com/mod/ixeris">Ixeris</a> by <a href="https://modrinth.com/user/decce6">decce6</a></li>
             <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
             <li><a href="https://modrinth.com/mod/modernfix">ModernFix</a> by <a href="https://modrinth.com/user/embeddedt">embeddedt</a></li>
             <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>
@@ -139,6 +141,7 @@
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
             <li><a href="https://modrinth.com/mod/indium">Indium</a> by <a href="https://modrinth.com/user/comp500">comp500</a></li>
+            <li><a href="https://modrinth.com/mod/ixeris">Ixeris</a> by <a href="https://modrinth.com/user/decce6">decce6</a></li>
             <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
             <li><a href="https://modrinth.com/mod/modernfix">ModernFix</a> by <a href="https://modrinth.com/user/embeddedt">embeddedt</a></li>
             <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>
@@ -158,6 +161,7 @@
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
             <li><a href="https://modrinth.com/mod/indium">Indium</a> by <a href="https://modrinth.com/user/comp500">comp500</a></li>
+            <li><a href="https://modrinth.com/mod/ixeris">Ixeris</a> by <a href="https://modrinth.com/user/decce6">decce6</a></li>
             <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
             <li><a href="https://modrinth.com/mod/modernfix">ModernFix</a> by <a href="https://modrinth.com/user/embeddedt">embeddedt</a></li>
             <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>
@@ -177,6 +181,7 @@
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
             <li><a href="https://modrinth.com/mod/indium">Indium</a> by <a href="https://modrinth.com/user/comp500">comp500</a></li>
+            <li><a href="https://modrinth.com/mod/ixeris">Ixeris</a> by <a href="https://modrinth.com/user/decce6">decce6</a></li>
             <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
             <li><a href="https://modrinth.com/mod/modernfix">ModernFix</a> by <a href="https://modrinth.com/user/embeddedt">embeddedt</a></li>
             <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>
@@ -546,6 +551,7 @@
             <li><a href="https://modrinth.com/mod/fabric-api">Fabric API</a> by <a href="https://modrinth.com/user/modmuss50">modmuss50</a></li>
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
+            <li><a href="https://modrinth.com/mod/ixeris">Ixeris</a> by <a href="https://modrinth.com/user/decce6">decce6</a></li>
             <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
             <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>
             <li><a href="https://modrinth.com/mod/noisium">Noisium</a> by <a href="https://modrinth.com/user/Steveplays">Steveplays</a></li>
@@ -611,6 +617,7 @@
             <li><a href="https://modrinth.com/mod/fabric-api">Fabric API</a> by <a href="https://modrinth.com/user/modmuss50">modmuss50</a></li>
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
+            <li><a href="https://modrinth.com/mod/ixeris">Ixeris</a> by <a href="https://modrinth.com/user/decce6">decce6</a></li>
             <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
             <li><a href="https://modrinth.com/mod/modernfix">ModernFix</a> by <a href="https://modrinth.com/user/embeddedt">embeddedt</a></li>
             <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>
@@ -648,6 +655,7 @@
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
             <li><a href="https://modrinth.com/mod/indium">Indium</a> by <a href="https://modrinth.com/user/comp500">comp500</a></li>
+            <li><a href="https://modrinth.com/mod/ixeris">Ixeris</a> by <a href="https://modrinth.com/user/decce6">decce6</a></li>
             <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
             <li><a href="https://modrinth.com/mod/modernfix">ModernFix</a> by <a href="https://modrinth.com/user/embeddedt">embeddedt</a></li>
             <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>
@@ -667,6 +675,7 @@
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
             <li><a href="https://modrinth.com/mod/indium">Indium</a> by <a href="https://modrinth.com/user/comp500">comp500</a></li>
+            <li><a href="https://modrinth.com/mod/ixeris">Ixeris</a> by <a href="https://modrinth.com/user/decce6">decce6</a></li>
             <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
             <li><a href="https://modrinth.com/mod/modernfix">ModernFix</a> by <a href="https://modrinth.com/user/embeddedt">embeddedt</a></li>
             <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>
@@ -686,6 +695,7 @@
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
             <li><a href="https://modrinth.com/mod/indium">Indium</a> by <a href="https://modrinth.com/user/comp500">comp500</a></li>
+            <li><a href="https://modrinth.com/mod/ixeris">Ixeris</a> by <a href="https://modrinth.com/user/decce6">decce6</a></li>
             <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
             <li><a href="https://modrinth.com/mod/modernfix">ModernFix</a> by <a href="https://modrinth.com/user/embeddedt">embeddedt</a></li>
             <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>

--- a/Quilt/1.19.4/modrinth.index.json
+++ b/Quilt/1.19.4/modrinth.index.json
@@ -1,10 +1,40 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "1.0.4",
+  "versionId": "1.1.0",
   "name": "Photon",
   "summary": "",
   "files": [
+    {
+      "path": "mods/entityculling-fabric-1.8.2-mc1.19.4.jar",
+      "hashes": {
+        "sha512": "a3a7dafae7defddae985f03ad7cf5c5b511352ceb8467c4d87245180375a1db2ebbec5ae709de687f64a6a157ea7669eda7c0be8e64b12dc71f38cf0b6a6eb49",
+        "sha1": "596137be484be7ebdeccae6009e587ee89cf1638"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/NNAgCjsB/versions/Qu62cqxc/entityculling-fabric-1.8.2-mc1.19.4.jar"
+      ],
+      "fileSize": 471282
+    },
+    {
+      "path": "mods/phosphor-fabric-mc1.19.x-0.8.1.jar",
+      "hashes": {
+        "sha512": "13a0707b7a92726aa3154bc40978f36bb340d643c1d60e9fa2cbf8f7b0c7d3ea03c2a079f46a487df05e944eec9f5779afae9e99be7f70373e8a31d59948d487",
+        "sha1": "2dd6f771ba5878d81892b9487f35340e94c87a1c"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/hEOCdOgW/versions/mc1.19.x-0.8.1/phosphor-fabric-mc1.19.x-0.8.1.jar"
+      ],
+      "fileSize": 88018
+    },
     {
       "path": "mods/moreculling-1.19.4-0.17.0.jar",
       "hashes": {
@@ -21,44 +51,29 @@
       "fileSize": 1235479
     },
     {
-      "path": "mods/lithium-fabric-mc1.19.4-0.11.1.jar",
+      "path": "mods/cloth-config-10.1.135-fabric.jar",
       "hashes": {
-        "sha1": "69aa137957af4f0f701f6a7663c6d8646f84a1cc",
-        "sha512": "f2bd271e30e5ed9f097d592db5e859208a1c6abe727dc51f83879b837c843b4f6453e99f1ca8d5225f896233ab8f7dbbb3300f10396d2a1cd2957937acfd1aa7"
+        "sha512": "b9aed46cff0bb4f33b55632de2234efc223d406cb33f264fc52048965c3570ae03d2493c5a93f46efd3bcf8c13f1d9cb420ff567f6c768108ddacb60918efbe6",
+        "sha1": "4f180acffa5c4abb1ed895c21265dc50b1420dff"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/14hWYkog/lithium-fabric-mc1.19.4-0.11.1.jar"
+        "https://cdn.modrinth.com/data/9s6osm5g/versions/ZTMfeJij/cloth-config-10.1.135-fabric.jar"
       ],
-      "fileSize": 639391
-    },
-    {
-      "path": "mods/enhancedblockentities-0.9+1.19.4.jar",
-      "hashes": {
-        "sha1": "97ffe54d7f5294fe6c8b529f51ef4b208b3ab1a7",
-        "sha512": "a60cbef0fc67789fafefafaf799107e17b96a2d1cf67f3b8396f8960a64308c9a9d33c822a0d62f6873bf2215c2026c46b78fa2d240c0055148230f13903636d"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/OVuFYfre/versions/Xdo5ZiRc/enhancedblockentities-0.9%2B1.19.4.jar"
-      ],
-      "fileSize": 492518
+      "fileSize": 1171035
     },
     {
       "path": "mods/c2me-fabric-mc1.19.4-0.2.0+alpha.10.66.jar",
       "hashes": {
-        "sha1": "5c681eb7358d91faf52c7b57d590c4fa274a6847",
-        "sha512": "1cbb1fe9b3538d953e341b499c67001f9fb142bf24853a6133dbc091aa8757d47d9949a1bc04106676cfb0b3ac280409fe017c1e3d4194bf35bb606eaea6c79d"
+        "sha512": "1cbb1fe9b3538d953e341b499c67001f9fb142bf24853a6133dbc091aa8757d47d9949a1bc04106676cfb0b3ac280409fe017c1e3d4194bf35bb606eaea6c79d",
+        "sha1": "5c681eb7358d91faf52c7b57d590c4fa274a6847"
       },
       "env": {
-        "client": "required",
-        "server": "required"
+        "server": "required",
+        "client": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/VSNURh3q/versions/uZ1nQtIu/c2me-fabric-mc1.19.4-0.2.0%2Balpha.10.66.jar"
@@ -66,10 +81,25 @@
       "fileSize": 1298898
     },
     {
+      "path": "mods/BadOptimizations-2.1.4-1.19.4.jar",
+      "hashes": {
+        "sha1": "330c0dd1f933d4ae5911cddc04324541dd0aea07",
+        "sha512": "2455f656b056a1e3365a90079a03ef16c0a0bb10571f2ad10f0870f16c55cb32c838d0ecfadc35726b28ee768522dadb80cd3a43aeb878fadcd348405741ee75"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/xhGlhCut/BadOptimizations-2.1.4-1.19.4.jar"
+      ],
+      "fileSize": 422943
+    },
+    {
       "path": "mods/indium-1.0.19+mc1.19.4.jar",
       "hashes": {
-        "sha1": "55638e279d8a19ea5df67ff86feb6350e95376e1",
-        "sha512": "676e217ba05ff49c3e8d5d801f7c157b5b988eb21a44694d5c72a279dcdfe30933f57639a66d9f49b9b10c26edb288e8aa212ba27d4bd9abe0212c52b2e9b193"
+        "sha512": "676e217ba05ff49c3e8d5d801f7c157b5b988eb21a44694d5c72a279dcdfe30933f57639a66d9f49b9b10c26edb288e8aa212ba27d4bd9abe0212c52b2e9b193",
+        "sha1": "55638e279d8a19ea5df67ff86feb6350e95376e1"
       },
       "env": {
         "client": "required",
@@ -79,36 +109,6 @@
         "https://cdn.modrinth.com/data/Orvt0mRa/versions/oYQsfz9e/indium-1.0.19%2Bmc1.19.4.jar"
       ],
       "fileSize": 104841
-    },
-    {
-      "path": "mods/qfapi-6.0.0-beta.11_qsl-5.0.0-beta.11_fapi-0.87.0_mc-1.19.4.jar",
-      "hashes": {
-        "sha512": "803b437084b698be11686cfda1e8056236e3a82126454a43927c9a5a5ae22f4cb2f0aaab50ffdd6dd04bb1e89fba9b81bb10867ae7a96884b4fa016974a4c0c5",
-        "sha1": "ee5bbcae4ba9231b53fc317e5fd4bf8352b6de8b"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/qvIfYCYJ/versions/BQoiDT9n/qfapi-6.0.0-beta.11_qsl-5.0.0-beta.11_fapi-0.87.0_mc-1.19.4.jar"
-      ],
-      "fileSize": 1901471
-    },
-    {
-      "path": "mods/phosphor-fabric-mc1.19.x-0.8.1.jar",
-      "hashes": {
-        "sha1": "2dd6f771ba5878d81892b9487f35340e94c87a1c",
-        "sha512": "13a0707b7a92726aa3154bc40978f36bb340d643c1d60e9fa2cbf8f7b0c7d3ea03c2a079f46a487df05e944eec9f5779afae9e99be7f70373e8a31d59948d487"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/hEOCdOgW/versions/mc1.19.x-0.8.1/phosphor-fabric-mc1.19.x-0.8.1.jar"
-      ],
-      "fileSize": 88018
     },
     {
       "path": "mods/ImmediatelyFast-Fabric-1.2.11+1.19.4.jar",
@@ -126,29 +126,29 @@
       "fileSize": 370128
     },
     {
-      "path": "mods/BadOptimizations-2.1.4-1.19.4.jar",
+      "path": "mods/modernfix-fabric-5.7.2+mc1.19.4.jar",
       "hashes": {
-        "sha512": "2455f656b056a1e3365a90079a03ef16c0a0bb10571f2ad10f0870f16c55cb32c838d0ecfadc35726b28ee768522dadb80cd3a43aeb878fadcd348405741ee75",
-        "sha1": "330c0dd1f933d4ae5911cddc04324541dd0aea07"
+        "sha512": "94877c4253224855753650e198df5cec908e4d07ae8f678982fa0a51a421d8f5659c2d505320a6af079da890bddca4f17d519484411bba877ca67fe545ec58b8",
+        "sha1": "53ec153757699d3998f74891d8ac8ef13b3da2aa"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/xhGlhCut/BadOptimizations-2.1.4-1.19.4.jar"
+        "https://cdn.modrinth.com/data/nmDcB62a/versions/LXlsO4Vo/modernfix-fabric-5.7.2%2Bmc1.19.4.jar"
       ],
-      "fileSize": 422943
+      "fileSize": 513020
     },
     {
       "path": "mods/sodium-fabric-mc1.19.4-0.4.10+build.24.jar",
       "hashes": {
-        "sha1": "b060680929d7a6d130fb980a9f9907461df05fa1",
-        "sha512": "61562626870aa4067657d2687d1fce80fb7d62af32fd68a22708e24ee5b84b39d16b26ccf4db8f53f2da42ba1916d6a5e11efc476cb5c2a8644207659fd5dfef"
+        "sha512": "61562626870aa4067657d2687d1fce80fb7d62af32fd68a22708e24ee5b84b39d16b26ccf4db8f53f2da42ba1916d6a5e11efc476cb5c2a8644207659fd5dfef",
+        "sha1": "b060680929d7a6d130fb980a9f9907461df05fa1"
       },
       "env": {
-        "client": "required",
-        "server": "required"
+        "server": "required",
+        "client": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/AANobbMI/versions/b4hTi3mo/sodium-fabric-mc1.19.4-0.4.10%2Bbuild.24.jar"
@@ -156,19 +156,19 @@
       "fileSize": 711302
     },
     {
-      "path": "mods/cloth-config-10.1.135-fabric.jar",
+      "path": "mods/qfapi-6.0.0-beta.11_qsl-5.0.0-beta.11_fapi-0.87.0_mc-1.19.4.jar",
       "hashes": {
-        "sha1": "4f180acffa5c4abb1ed895c21265dc50b1420dff",
-        "sha512": "b9aed46cff0bb4f33b55632de2234efc223d406cb33f264fc52048965c3570ae03d2493c5a93f46efd3bcf8c13f1d9cb420ff567f6c768108ddacb60918efbe6"
+        "sha1": "ee5bbcae4ba9231b53fc317e5fd4bf8352b6de8b",
+        "sha512": "803b437084b698be11686cfda1e8056236e3a82126454a43927c9a5a5ae22f4cb2f0aaab50ffdd6dd04bb1e89fba9b81bb10867ae7a96884b4fa016974a4c0c5"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/9s6osm5g/versions/ZTMfeJij/cloth-config-10.1.135-fabric.jar"
+        "https://cdn.modrinth.com/data/qvIfYCYJ/versions/BQoiDT9n/qfapi-6.0.0-beta.11_qsl-5.0.0-beta.11_fapi-0.87.0_mc-1.19.4.jar"
       ],
-      "fileSize": 1171035
+      "fileSize": 1901471
     },
     {
       "path": "mods/ferritecore-5.2.0-fabric.jar",
@@ -186,38 +186,53 @@
       "fileSize": 124924
     },
     {
-      "path": "mods/modernfix-fabric-5.7.2+mc1.19.4.jar",
+      "path": "mods/ixeris-3.4.0+1.20.1-fabric.jar",
       "hashes": {
-        "sha1": "53ec153757699d3998f74891d8ac8ef13b3da2aa",
-        "sha512": "94877c4253224855753650e198df5cec908e4d07ae8f678982fa0a51a421d8f5659c2d505320a6af079da890bddca4f17d519484411bba877ca67fe545ec58b8"
+        "sha512": "04793bf2ee38c94d13ba3843fa139b4c225fe474f31f66c0d7583fb9942f198c3e4f944fa94b8978df8a75e757d021437e804c3001c0deb338675871e4e1a0dd",
+        "sha1": "9808bd7c484a859ef8206c7b84a6435179c0c381"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/nmDcB62a/versions/LXlsO4Vo/modernfix-fabric-5.7.2%2Bmc1.19.4.jar"
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/6W1bmIHf/ixeris-3.4.0%2B1.20.1-fabric.jar"
       ],
-      "fileSize": 513020
+      "fileSize": 152331
     },
     {
-      "path": "mods/entityculling-fabric-1.8.2-mc1.19.4.jar",
+      "path": "mods/enhancedblockentities-0.9+1.19.4.jar",
       "hashes": {
-        "sha512": "a3a7dafae7defddae985f03ad7cf5c5b511352ceb8467c4d87245180375a1db2ebbec5ae709de687f64a6a157ea7669eda7c0be8e64b12dc71f38cf0b6a6eb49",
-        "sha1": "596137be484be7ebdeccae6009e587ee89cf1638"
+        "sha1": "97ffe54d7f5294fe6c8b529f51ef4b208b3ab1a7",
+        "sha512": "a60cbef0fc67789fafefafaf799107e17b96a2d1cf67f3b8396f8960a64308c9a9d33c822a0d62f6873bf2215c2026c46b78fa2d240c0055148230f13903636d"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/NNAgCjsB/versions/Qu62cqxc/entityculling-fabric-1.8.2-mc1.19.4.jar"
+        "https://cdn.modrinth.com/data/OVuFYfre/versions/Xdo5ZiRc/enhancedblockentities-0.9%2B1.19.4.jar"
       ],
-      "fileSize": 471282
+      "fileSize": 492518
+    },
+    {
+      "path": "mods/lithium-fabric-mc1.19.4-0.11.1.jar",
+      "hashes": {
+        "sha512": "f2bd271e30e5ed9f097d592db5e859208a1c6abe727dc51f83879b837c843b4f6453e99f1ca8d5225f896233ab8f7dbbb3300f10396d2a1cd2957937acfd1aa7",
+        "sha1": "69aa137957af4f0f701f6a7663c6d8646f84a1cc"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/14hWYkog/lithium-fabric-mc1.19.4-0.11.1.jar"
+      ],
+      "fileSize": 639391
     }
   ],
   "dependencies": {
-    "minecraft": "1.19.4",
-    "quilt-loader": "0.29.1"
+    "quilt-loader": "0.29.1",
+    "minecraft": "1.19.4"
   }
 }

--- a/Quilt/1.20.1/modrinth.index.json
+++ b/Quilt/1.20.1/modrinth.index.json
@@ -1,49 +1,19 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "1.0.15",
+  "versionId": "1.1.0",
   "name": "Photon",
   "summary": "",
   "files": [
     {
-      "path": "mods/ImmediatelyFast-Fabric-1.5.1+1.20.4.jar",
+      "path": "mods/enhancedblockentities-0.9+1.20.jar",
       "hashes": {
-        "sha1": "4050cb966b7211c234494075769bc8baf33e3c31",
-        "sha512": "23ddba94cb88591a9381b16c1e8ac2f59a609407d4e3400c083f85d416c37d5a7c42c67d6908d92a98f84fdf93ad083b9c5e8a041a1d90b0ffcca573ab0d3d92"
+        "sha512": "7e8b402fd25efd396bc7f0f25a663808ae9890accc227850c454dfcdc975657f22afceb15878e781485622434a6f6d60aff2a60264aa4425edd52ebe052a0de5",
+        "sha1": "61cfe50f69f8ef9e3640c0269ef158870f5b0410"
       },
       "env": {
         "server": "required",
         "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/5ZwdcRci/versions/zJD8Yaa3/ImmediatelyFast-Fabric-1.5.1%2B1.20.4.jar"
-      ],
-      "fileSize": 242574
-    },
-    {
-      "path": "mods/noisium-fabric-2.3.0+mc1.20-1.20.1.jar",
-      "hashes": {
-        "sha1": "be85535cf1efe82bd8c41bcf851becaad498a598",
-        "sha512": "f0abcdac514bd2b4eb6af3529eeb9980a6fef534d31244879acb291a9943151aeb34f372bf98ae01f6191870bf95e1c0bc36d522433353a1090b96e7ac03c417"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/KuNKN7d2/versions/erSJnRcq/noisium-fabric-2.3.0%2Bmc1.20-1.20.1.jar"
-      ],
-      "fileSize": 214902
-    },
-    {
-      "path": "mods/enhancedblockentities-0.9+1.20.jar",
-      "hashes": {
-        "sha1": "61cfe50f69f8ef9e3640c0269ef158870f5b0410",
-        "sha512": "7e8b402fd25efd396bc7f0f25a663808ae9890accc227850c454dfcdc975657f22afceb15878e781485622434a6f6d60aff2a60264aa4425edd52ebe052a0de5"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/OVuFYfre/versions/i3v1Skck/enhancedblockentities-0.9%2B1.20.jar"
@@ -66,70 +36,25 @@
       "fileSize": 2755789
     },
     {
-      "path": "mods/ferritecore-6.0.1-fabric.jar",
+      "path": "mods/indium-1.0.36+mc1.20.1.jar",
       "hashes": {
-        "sha1": "8fa3b84fc5860dbc30fdf8cced02af68dffcf3fa",
-        "sha512": "9b7dc686bfa7937815d88c7bbc6908857cd6646b05e7a96ddbdcada328a385bd4ba056532cd1d7df9d2d7f4265fd48bd49ff683f217f6d4e817177b87f6bc457"
+        "sha1": "d824614e7a173d273167969f427702f51846aca7",
+        "sha512": "7c5a1851f1fc08ae69318e151d07151fabba6cda2a24616c9251e1a4e5b969453e88b97d60f926271d60e3511bfc6fa05a64a108466efb7f29bec4519547e0c9"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/uXXizFIs/versions/unerR5MN/ferritecore-6.0.1-fabric.jar"
+        "https://cdn.modrinth.com/data/Orvt0mRa/versions/nQHYSjxO/indium-1.0.36%2Bmc1.20.1.jar"
       ],
-      "fileSize": 125197
-    },
-    {
-      "path": "mods/BadOptimizations-2.3.0-1.20.1.jar",
-      "hashes": {
-        "sha512": "288638bd5e4d9163205006ddc06eb6d962abcf9c49b602eeef3389e56184deee7844037a7cd41f770d6088a063756380afe1a6c456668356dd56b238834c3c49",
-        "sha1": "b86ce6a5ed4f71a13f6d2976ffe6471cef29beb7"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/RPOjbIwJ/BadOptimizations-2.3.0-1.20.1.jar"
-      ],
-      "fileSize": 452304
-    },
-    {
-      "path": "mods/lithium-fabric-mc1.20.1-0.11.3.jar",
-      "hashes": {
-        "sha1": "7dc706d892b4c7cff0f7648e6b6256a64c3abec2",
-        "sha512": "dc9bc65146f41cf99c46b46216dd3645be7c45cfeb2bc7cdceaa11bcd57771cdf2c30e84ce057f12b8dbf0d54fb808143cf46d92626370011ba5112bec18e720"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/vuuAe7ZA/lithium-fabric-mc1.20.1-0.11.3.jar"
-      ],
-      "fileSize": 706600
-    },
-    {
-      "path": "mods/entityculling-fabric-1.8.2-mc1.20.1.jar",
-      "hashes": {
-        "sha512": "79bdedd7fb6eb5a1bd7178e5bce393e51e34d568f2b61ab7129eb93997b73c2cc749a4a20b522e8bb7c99e955ec2438ed4f3a855709ae37a20240abb084721b2",
-        "sha1": "aafa013a11005e426ed912461b361be44aa0bad4"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/NNAgCjsB/versions/3TCgPw5u/entityculling-fabric-1.8.2-mc1.20.1.jar"
-      ],
-      "fileSize": 470860
+      "fileSize": 105382
     },
     {
       "path": "mods/cloth-config-11.1.136-fabric.jar",
       "hashes": {
-        "sha512": "2da85c071c854223cc30c8e46794391b77e53f28ecdbbde59dc83b3dbbdfc74be9e68da9ed464e7f98b4361033899ba4f681ebff1f35edc2c60e599a59796f1c",
-        "sha1": "d5fe84a0cc9ed5c7290a76ba570e1f8716afecab"
+        "sha1": "d5fe84a0cc9ed5c7290a76ba570e1f8716afecab",
+        "sha512": "2da85c071c854223cc30c8e46794391b77e53f28ecdbbde59dc83b3dbbdfc74be9e68da9ed464e7f98b4361033899ba4f681ebff1f35edc2c60e599a59796f1c"
       },
       "env": {
         "server": "required",
@@ -141,19 +66,109 @@
       "fileSize": 1172214
     },
     {
-      "path": "mods/indium-1.0.36+mc1.20.1.jar",
+      "path": "mods/ImmediatelyFast-Fabric-1.5.1+1.20.4.jar",
       "hashes": {
-        "sha512": "7c5a1851f1fc08ae69318e151d07151fabba6cda2a24616c9251e1a4e5b969453e88b97d60f926271d60e3511bfc6fa05a64a108466efb7f29bec4519547e0c9",
-        "sha1": "d824614e7a173d273167969f427702f51846aca7"
+        "sha1": "4050cb966b7211c234494075769bc8baf33e3c31",
+        "sha512": "23ddba94cb88591a9381b16c1e8ac2f59a609407d4e3400c083f85d416c37d5a7c42c67d6908d92a98f84fdf93ad083b9c5e8a041a1d90b0ffcca573ab0d3d92"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/Orvt0mRa/versions/nQHYSjxO/indium-1.0.36%2Bmc1.20.1.jar"
+        "https://cdn.modrinth.com/data/5ZwdcRci/versions/zJD8Yaa3/ImmediatelyFast-Fabric-1.5.1%2B1.20.4.jar"
       ],
-      "fileSize": 105382
+      "fileSize": 242574
+    },
+    {
+      "path": "mods/c2me-fabric-mc1.20.1-0.2.0+alpha.11.16.jar",
+      "hashes": {
+        "sha1": "94d96b5fffd9e98bd8448dcdd9e27f60511b1d29",
+        "sha512": "359c715fd6a0464192d36b4d9dbb7927776eaae498f0cab939b49740fc724bda83aaf4f069f395dc5975d1e82762ee3b602111d9375eb27ab6f5360c4b17f2ff"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/VSNURh3q/versions/s4WOiNtz/c2me-fabric-mc1.20.1-0.2.0%2Balpha.11.16.jar"
+      ],
+      "fileSize": 1426500
+    },
+    {
+      "path": "mods/entityculling-fabric-1.8.2-mc1.20.1.jar",
+      "hashes": {
+        "sha512": "79bdedd7fb6eb5a1bd7178e5bce393e51e34d568f2b61ab7129eb93997b73c2cc749a4a20b522e8bb7c99e955ec2438ed4f3a855709ae37a20240abb084721b2",
+        "sha1": "aafa013a11005e426ed912461b361be44aa0bad4"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/NNAgCjsB/versions/3TCgPw5u/entityculling-fabric-1.8.2-mc1.20.1.jar"
+      ],
+      "fileSize": 470860
+    },
+    {
+      "path": "mods/noisium-fabric-2.3.0+mc1.20-1.20.1.jar",
+      "hashes": {
+        "sha1": "be85535cf1efe82bd8c41bcf851becaad498a598",
+        "sha512": "f0abcdac514bd2b4eb6af3529eeb9980a6fef534d31244879acb291a9943151aeb34f372bf98ae01f6191870bf95e1c0bc36d522433353a1090b96e7ac03c417"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/KuNKN7d2/versions/erSJnRcq/noisium-fabric-2.3.0%2Bmc1.20-1.20.1.jar"
+      ],
+      "fileSize": 214902
+    },
+    {
+      "path": "mods/ixeris-3.4.0+1.20.1-fabric.jar",
+      "hashes": {
+        "sha512": "04793bf2ee38c94d13ba3843fa139b4c225fe474f31f66c0d7583fb9942f198c3e4f944fa94b8978df8a75e757d021437e804c3001c0deb338675871e4e1a0dd",
+        "sha1": "9808bd7c484a859ef8206c7b84a6435179c0c381"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/6W1bmIHf/ixeris-3.4.0%2B1.20.1-fabric.jar"
+      ],
+      "fileSize": 152331
+    },
+    {
+      "path": "mods/moreculling-1.20.4-0.24.0.jar",
+      "hashes": {
+        "sha512": "3a8accedfa48ce86b4091ce7994d63b2c7d1f6654119a5dc8430bd7370084bf04801c71600bb2b1546a58aef972797048f86eebbff2a666905a86c2b1cf7632e",
+        "sha1": "a40f2aa346140a4fee2079d845c62ee87454bdb6"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/51shyZVL/versions/3m5znPWm/moreculling-1.20.4-0.24.0.jar"
+      ],
+      "fileSize": 272851
+    },
+    {
+      "path": "mods/BadOptimizations-2.3.0-1.20.1.jar",
+      "hashes": {
+        "sha1": "b86ce6a5ed4f71a13f6d2976ffe6471cef29beb7",
+        "sha512": "288638bd5e4d9163205006ddc06eb6d962abcf9c49b602eeef3389e56184deee7844037a7cd41f770d6088a063756380afe1a6c456668356dd56b238834c3c49"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/RPOjbIwJ/BadOptimizations-2.3.0-1.20.1.jar"
+      ],
+      "fileSize": 452304
     },
     {
       "path": "mods/modernfix-fabric-5.24.4+mc1.20.1.jar",
@@ -162,8 +177,8 @@
         "sha1": "3d20fa94c463113a24346ed544f4ca95c54bae8d"
       },
       "env": {
-        "server": "required",
-        "client": "required"
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/nmDcB62a/versions/PSpecC1r/modernfix-fabric-5.24.4%2Bmc1.20.1.jar"
@@ -173,12 +188,12 @@
     {
       "path": "mods/sodium-fabric-0.5.13+mc1.20.1.jar",
       "hashes": {
-        "sha1": "bcdbf37d9494e405cba210d7a80ed58e756297b5",
-        "sha512": "81c64f9c2d3402dfa43ee54d8f5a054f5243bfb08984e3addcab9fe885073c79c43c1c8c41e8f30b625d26a656f82a8e5f370bbbbf222ff1c08f4b324edb7ea4"
+        "sha512": "81c64f9c2d3402dfa43ee54d8f5a054f5243bfb08984e3addcab9fe885073c79c43c1c8c41e8f30b625d26a656f82a8e5f370bbbbf222ff1c08f4b324edb7ea4",
+        "sha1": "bcdbf37d9494e405cba210d7a80ed58e756297b5"
       },
       "env": {
-        "server": "required",
-        "client": "required"
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/AANobbMI/versions/OihdIimA/sodium-fabric-0.5.13%2Bmc1.20.1.jar"
@@ -186,34 +201,34 @@
       "fileSize": 971552
     },
     {
-      "path": "mods/c2me-fabric-mc1.20.1-0.2.0+alpha.11.16.jar",
+      "path": "mods/ferritecore-6.0.1-fabric.jar",
       "hashes": {
-        "sha512": "359c715fd6a0464192d36b4d9dbb7927776eaae498f0cab939b49740fc724bda83aaf4f069f395dc5975d1e82762ee3b602111d9375eb27ab6f5360c4b17f2ff",
-        "sha1": "94d96b5fffd9e98bd8448dcdd9e27f60511b1d29"
+        "sha512": "9b7dc686bfa7937815d88c7bbc6908857cd6646b05e7a96ddbdcada328a385bd4ba056532cd1d7df9d2d7f4265fd48bd49ff683f217f6d4e817177b87f6bc457",
+        "sha1": "8fa3b84fc5860dbc30fdf8cced02af68dffcf3fa"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/VSNURh3q/versions/s4WOiNtz/c2me-fabric-mc1.20.1-0.2.0%2Balpha.11.16.jar"
+        "https://cdn.modrinth.com/data/uXXizFIs/versions/unerR5MN/ferritecore-6.0.1-fabric.jar"
       ],
-      "fileSize": 1426500
+      "fileSize": 125197
     },
     {
-      "path": "mods/moreculling-1.20.4-0.24.0.jar",
+      "path": "mods/lithium-fabric-mc1.20.1-0.11.3.jar",
       "hashes": {
-        "sha512": "3a8accedfa48ce86b4091ce7994d63b2c7d1f6654119a5dc8430bd7370084bf04801c71600bb2b1546a58aef972797048f86eebbff2a666905a86c2b1cf7632e",
-        "sha1": "a40f2aa346140a4fee2079d845c62ee87454bdb6"
+        "sha1": "7dc706d892b4c7cff0f7648e6b6256a64c3abec2",
+        "sha512": "dc9bc65146f41cf99c46b46216dd3645be7c45cfeb2bc7cdceaa11bcd57771cdf2c30e84ce057f12b8dbf0d54fb808143cf46d92626370011ba5112bec18e720"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/51shyZVL/versions/3m5znPWm/moreculling-1.20.4-0.24.0.jar"
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/vuuAe7ZA/lithium-fabric-mc1.20.1-0.11.3.jar"
       ],
-      "fileSize": 272851
+      "fileSize": 706600
     }
   ],
   "dependencies": {

--- a/Quilt/1.20.4/modrinth.index.json
+++ b/Quilt/1.20.4/modrinth.index.json
@@ -1,39 +1,84 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "1.0.7",
+  "versionId": "1.1.0",
   "name": "Photon",
   "summary": "",
   "files": [
     {
-      "path": "mods/sodium-fabric-0.5.8+mc1.20.4.jar",
+      "path": "mods/ImmediatelyFast-Fabric-1.5.1+1.20.4.jar",
       "hashes": {
-        "sha1": "4c38d7b01660a27a98406767c613b3f28b6c9dfe",
-        "sha512": "bd00b956bde1205171e744a6a3780e835fb6928eb667fb2b56467818c979fb1e8c82561380a71a7dbfa1516cd4b6cf9087ca99f1ae066da6d65af2c828b8d554"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/AANobbMI/versions/4GyXKCLd/sodium-fabric-0.5.8%2Bmc1.20.4.jar"
-      ],
-      "fileSize": 949085
-    },
-    {
-      "path": "mods/moreculling-1.20.4-0.24.0.jar",
-      "hashes": {
-        "sha512": "3a8accedfa48ce86b4091ce7994d63b2c7d1f6654119a5dc8430bd7370084bf04801c71600bb2b1546a58aef972797048f86eebbff2a666905a86c2b1cf7632e",
-        "sha1": "a40f2aa346140a4fee2079d845c62ee87454bdb6"
+        "sha1": "4050cb966b7211c234494075769bc8baf33e3c31",
+        "sha512": "23ddba94cb88591a9381b16c1e8ac2f59a609407d4e3400c083f85d416c37d5a7c42c67d6908d92a98f84fdf93ad083b9c5e8a041a1d90b0ffcca573ab0d3d92"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
+        "https://cdn.modrinth.com/data/5ZwdcRci/versions/zJD8Yaa3/ImmediatelyFast-Fabric-1.5.1%2B1.20.4.jar"
+      ],
+      "fileSize": 242574
+    },
+    {
+      "path": "mods/BadOptimizations-2.3.0-1.20.2-20.4.jar",
+      "hashes": {
+        "sha512": "7e544e5b18ee1b276906f74a65ebfcca4f34b8b1721246dbf0644ed1c76f18f267f1475ba553732255496f41cfd2febf52b9da9181657b53e0b9919340fa5b18",
+        "sha1": "70cfad11ea5b8a9b6001d815199f548104fd9d12"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/irRJRJN4/BadOptimizations-2.3.0-1.20.2-20.4.jar"
+      ],
+      "fileSize": 147469
+    },
+    {
+      "path": "mods/cloth-config-13.0.138-fabric.jar",
+      "hashes": {
+        "sha512": "3863fb95cc57526c6876cb60600f2e4282a5fa8d997d981e984da48f34be654cd0c5fc09e7d77079a393b2d7e3e48baabb756ad84ea58881b22ea771f43baa4a",
+        "sha1": "e374f80329cea3d73e10e31839fe79d5a4fc0b30"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/9s6osm5g/versions/2deYQULk/cloth-config-13.0.138-fabric.jar"
+      ],
+      "fileSize": 1154870
+    },
+    {
+      "path": "mods/moreculling-1.20.4-0.24.0.jar",
+      "hashes": {
+        "sha1": "a40f2aa346140a4fee2079d845c62ee87454bdb6",
+        "sha512": "3a8accedfa48ce86b4091ce7994d63b2c7d1f6654119a5dc8430bd7370084bf04801c71600bb2b1546a58aef972797048f86eebbff2a666905a86c2b1cf7632e"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
         "https://cdn.modrinth.com/data/51shyZVL/versions/3m5znPWm/moreculling-1.20.4-0.24.0.jar"
       ],
       "fileSize": 272851
+    },
+    {
+      "path": "mods/noisium-fabric-2.3.0+mc1.20.2-1.20.4.jar",
+      "hashes": {
+        "sha1": "31be12110ac95503676adfaca2d9ac179e8b2072",
+        "sha512": "249cf90051e808a224a22b6d45812831793368297c5873512a25a7e5f4b866c3d2a625b04f74ed8d9987b6171e7cca085ed8d7a100336f395cc037f1493e0e2b"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/KuNKN7d2/versions/RmNpWBtf/noisium-fabric-2.3.0%2Bmc1.20.2-1.20.4.jar"
+      ],
+      "fileSize": 214908
     },
     {
       "path": "mods/enhancedblockentities-0.10.1+1.20.4.jar",
@@ -51,49 +96,79 @@
       "fileSize": 330603
     },
     {
-      "path": "mods/ImmediatelyFast-Fabric-1.5.1+1.20.4.jar",
+      "path": "mods/indium-1.0.31+mc1.20.4.jar",
       "hashes": {
-        "sha512": "23ddba94cb88591a9381b16c1e8ac2f59a609407d4e3400c083f85d416c37d5a7c42c67d6908d92a98f84fdf93ad083b9c5e8a041a1d90b0ffcca573ab0d3d92",
-        "sha1": "4050cb966b7211c234494075769bc8baf33e3c31"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/5ZwdcRci/versions/zJD8Yaa3/ImmediatelyFast-Fabric-1.5.1%2B1.20.4.jar"
-      ],
-      "fileSize": 242574
-    },
-    {
-      "path": "mods/noisium-fabric-2.3.0+mc1.20.2-1.20.4.jar",
-      "hashes": {
-        "sha1": "31be12110ac95503676adfaca2d9ac179e8b2072",
-        "sha512": "249cf90051e808a224a22b6d45812831793368297c5873512a25a7e5f4b866c3d2a625b04f74ed8d9987b6171e7cca085ed8d7a100336f395cc037f1493e0e2b"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/KuNKN7d2/versions/RmNpWBtf/noisium-fabric-2.3.0%2Bmc1.20.2-1.20.4.jar"
-      ],
-      "fileSize": 214908
-    },
-    {
-      "path": "mods/modernfix-fabric-5.17.0+mc1.20.4.jar",
-      "hashes": {
-        "sha1": "cf5f1f0db74b0385c2738c6fbf8347e7e68100d6",
-        "sha512": "8404bc285100746ac76467094b2b4feb132e046272780c4c8a6d4bd4336fad70073734438e9f37bf7e46ffa65dbf2f06ab10232b09c3911c08215dfcf71fca0e"
+        "sha1": "fe6d0513ac332d890f1bd9bb9354a8e240b8f0e5",
+        "sha512": "27b4a73ca990742e27eee4348553c86c96c19fddcd0763892029f67ddbde42dc03c0ac21230403ae6b4ce4da315d0d49f582d3daab413b9ea84fd6d172ee7c4f"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/nmDcB62a/versions/CV2Vtn5m/modernfix-fabric-5.17.0%2Bmc1.20.4.jar"
+        "https://cdn.modrinth.com/data/Orvt0mRa/versions/VlLxDisa/indium-1.0.31%2Bmc1.20.4.jar"
       ],
-      "fileSize": 458056
+      "fileSize": 105350
+    },
+    {
+      "path": "mods/sodium-fabric-0.5.8+mc1.20.4.jar",
+      "hashes": {
+        "sha1": "4c38d7b01660a27a98406767c613b3f28b6c9dfe",
+        "sha512": "bd00b956bde1205171e744a6a3780e835fb6928eb667fb2b56467818c979fb1e8c82561380a71a7dbfa1516cd4b6cf9087ca99f1ae066da6d65af2c828b8d554"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/AANobbMI/versions/4GyXKCLd/sodium-fabric-0.5.8%2Bmc1.20.4.jar"
+      ],
+      "fileSize": 949085
+    },
+    {
+      "path": "mods/lithium-fabric-mc1.20.4-0.12.1.jar",
+      "hashes": {
+        "sha512": "70bea154eaafb2e4b5cb755cdb12c55d50f9296ab4c2855399da548f72d6d24c0a9f77e3da2b2ea5f47fa91d1258df4d08c6c6f24a25da887ed71cea93502508",
+        "sha1": "4a0744beb2246d93cb475d21a5a53faa556956e0"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/nMhjKWVE/lithium-fabric-mc1.20.4-0.12.1.jar"
+      ],
+      "fileSize": 716022
+    },
+    {
+      "path": "mods/ixeris-3.4.0+1.20.4-fabric.jar",
+      "hashes": {
+        "sha1": "2df154508d805189639b7f6b00e89e3e607c6b32",
+        "sha512": "9e291109935601ea5415218590ae5887dcc9c4a73e14e49938bd3e53168bd7e7322fedd378cf520361aa564554c92e4b435f6af74c458e3705bd616969630089"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/2QN84gzC/ixeris-3.4.0%2B1.20.4-fabric.jar"
+      ],
+      "fileSize": 152384
+    },
+    {
+      "path": "mods/ferritecore-6.0.3-fabric.jar",
+      "hashes": {
+        "sha1": "f2bbb773f4213d36201b76820f206e2a6f213c0c",
+        "sha512": "709ab6362dd1dcc432edd1e6c33aafba6f2d12be701bc14911107340f8ac2466779c4e57d8a303f0350c46478f23008e6eeca78e4eadedd0bdee63d4ae72ed9a"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/uXXizFIs/versions/pguEMpy9/ferritecore-6.0.3-fabric.jar"
+      ],
+      "fileSize": 125100
     },
     {
       "path": "mods/c2me-fabric-mc1.20.4-0.2.0+alpha.11.72.jar",
@@ -111,55 +186,25 @@
       "fileSize": 1289505
     },
     {
-      "path": "mods/indium-1.0.31+mc1.20.4.jar",
+      "path": "mods/modernfix-fabric-5.17.0+mc1.20.4.jar",
       "hashes": {
-        "sha512": "27b4a73ca990742e27eee4348553c86c96c19fddcd0763892029f67ddbde42dc03c0ac21230403ae6b4ce4da315d0d49f582d3daab413b9ea84fd6d172ee7c4f",
-        "sha1": "fe6d0513ac332d890f1bd9bb9354a8e240b8f0e5"
+        "sha512": "8404bc285100746ac76467094b2b4feb132e046272780c4c8a6d4bd4336fad70073734438e9f37bf7e46ffa65dbf2f06ab10232b09c3911c08215dfcf71fca0e",
+        "sha1": "cf5f1f0db74b0385c2738c6fbf8347e7e68100d6"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/Orvt0mRa/versions/VlLxDisa/indium-1.0.31%2Bmc1.20.4.jar"
+        "https://cdn.modrinth.com/data/nmDcB62a/versions/CV2Vtn5m/modernfix-fabric-5.17.0%2Bmc1.20.4.jar"
       ],
-      "fileSize": 105350
-    },
-    {
-      "path": "mods/lithium-fabric-mc1.20.4-0.12.1.jar",
-      "hashes": {
-        "sha1": "4a0744beb2246d93cb475d21a5a53faa556956e0",
-        "sha512": "70bea154eaafb2e4b5cb755cdb12c55d50f9296ab4c2855399da548f72d6d24c0a9f77e3da2b2ea5f47fa91d1258df4d08c6c6f24a25da887ed71cea93502508"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/nMhjKWVE/lithium-fabric-mc1.20.4-0.12.1.jar"
-      ],
-      "fileSize": 716022
-    },
-    {
-      "path": "mods/quilted-fabric-api-9.0.0-alpha.8+0.97.0-1.20.4.jar",
-      "hashes": {
-        "sha512": "ae742daae860126d26a0397059345f8361880cf6330d0e38e078bc6bbd79da3bbaea10ff7b663db5d174075bcf9fc67a3a12d496fa86ac8849aecf0a3fea7da0",
-        "sha1": "34d0e558366a31d1dfc28fc7b6ae8f61d7b2ce11"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/qvIfYCYJ/versions/AljqyvST/quilted-fabric-api-9.0.0-alpha.8%2B0.97.0-1.20.4.jar"
-      ],
-      "fileSize": 1987276
+      "fileSize": 458056
     },
     {
       "path": "mods/entityculling-fabric-1.8.2-mc1.20.4.jar",
       "hashes": {
-        "sha512": "1951e3a233837cb00cd1ea49bcbb8576bb991b6a4c70f776fc3d1756c7bbdefc7a796f292581c417a5c9a84951c735cf767ab7d082a0f89252d5727ff07b8e23",
-        "sha1": "cfc97d8bd097898867598a8e0dcc2bef64e09887"
+        "sha1": "cfc97d8bd097898867598a8e0dcc2bef64e09887",
+        "sha512": "1951e3a233837cb00cd1ea49bcbb8576bb991b6a4c70f776fc3d1756c7bbdefc7a796f292581c417a5c9a84951c735cf767ab7d082a0f89252d5727ff07b8e23"
       },
       "env": {
         "server": "required",
@@ -171,49 +216,19 @@
       "fileSize": 470518
     },
     {
-      "path": "mods/cloth-config-13.0.138-fabric.jar",
+      "path": "mods/quilted-fabric-api-9.0.0-alpha.8+0.97.0-1.20.4.jar",
       "hashes": {
-        "sha512": "3863fb95cc57526c6876cb60600f2e4282a5fa8d997d981e984da48f34be654cd0c5fc09e7d77079a393b2d7e3e48baabb756ad84ea58881b22ea771f43baa4a",
-        "sha1": "e374f80329cea3d73e10e31839fe79d5a4fc0b30"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/9s6osm5g/versions/2deYQULk/cloth-config-13.0.138-fabric.jar"
-      ],
-      "fileSize": 1154870
-    },
-    {
-      "path": "mods/BadOptimizations-2.3.0-1.20.2-20.4.jar",
-      "hashes": {
-        "sha1": "70cfad11ea5b8a9b6001d815199f548104fd9d12",
-        "sha512": "7e544e5b18ee1b276906f74a65ebfcca4f34b8b1721246dbf0644ed1c76f18f267f1475ba553732255496f41cfd2febf52b9da9181657b53e0b9919340fa5b18"
+        "sha1": "34d0e558366a31d1dfc28fc7b6ae8f61d7b2ce11",
+        "sha512": "ae742daae860126d26a0397059345f8361880cf6330d0e38e078bc6bbd79da3bbaea10ff7b663db5d174075bcf9fc67a3a12d496fa86ac8849aecf0a3fea7da0"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/irRJRJN4/BadOptimizations-2.3.0-1.20.2-20.4.jar"
+        "https://cdn.modrinth.com/data/qvIfYCYJ/versions/AljqyvST/quilted-fabric-api-9.0.0-alpha.8%2B0.97.0-1.20.4.jar"
       ],
-      "fileSize": 147469
-    },
-    {
-      "path": "mods/ferritecore-6.0.3-fabric.jar",
-      "hashes": {
-        "sha1": "f2bbb773f4213d36201b76820f206e2a6f213c0c",
-        "sha512": "709ab6362dd1dcc432edd1e6c33aafba6f2d12be701bc14911107340f8ac2466779c4e57d8a303f0350c46478f23008e6eeca78e4eadedd0bdee63d4ae72ed9a"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/uXXizFIs/versions/pguEMpy9/ferritecore-6.0.3-fabric.jar"
-      ],
-      "fileSize": 125100
+      "fileSize": 1987276
     }
   ],
   "dependencies": {

--- a/Quilt/1.21.1/modrinth.index.json
+++ b/Quilt/1.21.1/modrinth.index.json
@@ -1,49 +1,19 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "1.0.9",
+  "versionId": "1.1.0",
   "name": "Photon",
   "summary": "",
   "files": [
     {
-      "path": "mods/fabric-api-0.116.4+1.21.1.jar",
+      "path": "mods/c2me-fabric-mc1.21.1-0.3.0+alpha.0.320.jar",
       "hashes": {
-        "sha512": "95060def77b54ba6c6eb5af45b478ec6926f33f145d8f3933cd90cb2b6ab6913459d3d0afa3afcb01fca07d714628414a41ee8b6845261e88d92b83bfc668ad8",
-        "sha1": "39d1a6b6213d012649821ecc516ed5b5142478ef"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/P7dR8mSH/versions/19viawBV/fabric-api-0.116.4%2B1.21.1.jar"
-      ],
-      "fileSize": 2423497
-    },
-    {
-      "path": "mods/moreculling-fabric-1.21.1-1.0.6.jar",
-      "hashes": {
-        "sha512": "c6a6db1e2b63084457358171175ddf6061b32d31843f982001720c34433ae96cb13d72b910dc486ad1556e9db55352df3619f131c733bf843d3273d248989b05",
-        "sha1": "e14150baf443abc24ee6236b837c287dd5950e95"
+        "sha1": "fe53bfdccad85f039de2d1d04f0791caf91e12c8",
+        "sha512": "5ae8ff5e2d6b849aee1e71ee5ec22f68c3713617b9e246de7fdfea8af8d7a84d63f2cb13ed0949dfb119c7d647295244b476d34c618baf3bed171e33fc3872d6"
       },
       "env": {
         "client": "required",
         "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/51shyZVL/versions/1V6UtDhN/moreculling-fabric-1.21.1-1.0.6.jar"
-      ],
-      "fileSize": 345544
-    },
-    {
-      "path": "mods/c2me-fabric-mc1.21.1-0.3.0+alpha.0.320.jar",
-      "hashes": {
-        "sha512": "5ae8ff5e2d6b849aee1e71ee5ec22f68c3713617b9e246de7fdfea8af8d7a84d63f2cb13ed0949dfb119c7d647295244b476d34c618baf3bed171e33fc3872d6",
-        "sha1": "fe53bfdccad85f039de2d1d04f0791caf91e12c8"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/VSNURh3q/versions/oXr69pco/c2me-fabric-mc1.21.1-0.3.0%2Balpha.0.320.jar"
@@ -51,44 +21,14 @@
       "fileSize": 4667083
     },
     {
-      "path": "mods/lithium-fabric-0.15.0+mc1.21.1.jar",
-      "hashes": {
-        "sha1": "b7d77602807f2c7cd7132741244bf8c0b8dec6c1",
-        "sha512": "fd3215501ebe8f6590cdf1ccc58182873cad8d74ebc4b0b3a2f5724748b9cb04c2b967503c072311dfbca9ba856195dc4662f3395a071b294fa0acfdd2a86bf6"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/MM5BBBOK/lithium-fabric-0.15.0%2Bmc1.21.1.jar"
-      ],
-      "fileSize": 771768
-    },
-    {
-      "path": "mods/sodium-fabric-0.6.13+mc1.21.1.jar",
-      "hashes": {
-        "sha512": "13032e064c554fc8671573dadb07bc70e6ea2f68706c65c086c4feb1d2f664346a3414cbf9d1367b42b8d063a35e40f2f967ef9af31642e1f0093b852161fe91",
-        "sha1": "928a2598178c3a58b0638bab842f467d2e49251a"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/AANobbMI/versions/u1OEbNKx/sodium-fabric-0.6.13%2Bmc1.21.1.jar"
-      ],
-      "fileSize": 1297761
-    },
-    {
       "path": "mods/entityculling-fabric-1.8.2-mc1.21.jar",
       "hashes": {
-        "sha1": "9b21d48e4c95ebf94aac46b5fcd6a4d86fd7cfc7",
-        "sha512": "5b53406eccf6518f6bf0f33c9cafa47745f9d80acf92e97163d1feb107c63634dbf5cd86cb9c1ae55fca865dbd94d3ccb4c2575c4ad934620492d2d550efbe9f"
+        "sha512": "5b53406eccf6518f6bf0f33c9cafa47745f9d80acf92e97163d1feb107c63634dbf5cd86cb9c1ae55fca865dbd94d3ccb4c2575c4ad934620492d2d550efbe9f",
+        "sha1": "9b21d48e4c95ebf94aac46b5fcd6a4d86fd7cfc7"
       },
       "env": {
-        "client": "required",
-        "server": "required"
+        "server": "required",
+        "client": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/NNAgCjsB/versions/ivkfruZP/entityculling-fabric-1.8.2-mc1.21.jar"
@@ -96,79 +36,19 @@
       "fileSize": 469193
     },
     {
-      "path": "mods/noisium-fabric-2.3.0+mc1.21-1.21.1.jar",
+      "path": "mods/ferritecore-7.0.2-hotfix-fabric.jar",
       "hashes": {
-        "sha512": "606ba78cf7f30d99e417c96aa042f600c1b626ed9c783919496d139de650013f1434fcf93545782e3889660322837ce6e85530d9e1a5cc20f9ad161357ede43e",
-        "sha1": "642a672cfc60ff1e1262a39d7e160b1381c5120c"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/KuNKN7d2/versions/4sGQgiu2/noisium-fabric-2.3.0%2Bmc1.21-1.21.1.jar"
-      ],
-      "fileSize": 216183
-    },
-    {
-      "path": "mods/cloth-config-15.0.140-fabric.jar",
-      "hashes": {
-        "sha512": "1b3f5db4fc1d481704053db9837d530919374bf7518d7cede607360f0348c04fc6347a3a72ccfef355559e1f4aef0b650cd58e5ee79c73b12ff0fc2746797a00",
-        "sha1": "5d82342a2df53fd6df712bfdd583a811572918a4"
+        "sha512": "ca975bd3708cd96d30cf1447ac8883572113562eb2dd697e60c1cf382d6b70d0b1a511fcbfd042c51b2cf5d5ffc718b847f845e4c8a3e421e8c9ee741119a421",
+        "sha1": "48ee764932d0c8ec81a2223dbe333886938e512c"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/9s6osm5g/versions/HpMb5wGb/cloth-config-15.0.140-fabric.jar"
+        "https://cdn.modrinth.com/data/uXXizFIs/versions/bwKMSBhn/ferritecore-7.0.2-hotfix-fabric.jar"
       ],
-      "fileSize": 1157166
-    },
-    {
-      "path": "mods/enhancedblockentities-0.10.2+1.21.jar",
-      "hashes": {
-        "sha1": "d81359d77fc7c5437f3e83e519dc2f869300f0cd",
-        "sha512": "60e01db603fcf1392c0cd5c3ce742e568f7d445d83fe60828b21f546e7d29fb6947231f22d28e29b07f4bdcb767b6dc2a2398b4decea665ecba1166690a44d49"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/OVuFYfre/versions/HBZAPs3u/enhancedblockentities-0.10.2%2B1.21.jar"
-      ],
-      "fileSize": 201157
-    },
-    {
-      "path": "mods/BadOptimizations-2.3.0-1.21.1.jar",
-      "hashes": {
-        "sha1": "0d759c0996fbfc1ed4066170351722e6d9e52884",
-        "sha512": "a9d78ab8d84d0ba3ebfd77eb3c4f585b9c3f0cad8e59b0ecef8c3ba107067342d7549f275c8fe45a5d4f35f7d848a15c184ad6e369044e659d17ce08afe91a77"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/AQrpXs3f/BadOptimizations-2.3.0-1.21.1.jar"
-      ],
-      "fileSize": 123862
-    },
-    {
-      "path": "mods/modernfix-fabric-5.24.3+mc1.21.1.jar",
-      "hashes": {
-        "sha1": "fd5bd05c9380243b3fa86e42b3649d8cdb235a60",
-        "sha512": "43a81e63638387701edc49aabbde9e293890165e6e3b2df378aeabf56ea41fd666c1841cfac488e8d723ee99a673e09de4cc37a3e2141e04216f4aad5254dae1"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/nmDcB62a/versions/xDJFoW9U/modernfix-fabric-5.24.3%2Bmc1.21.1.jar"
-      ],
-      "fileSize": 460259
+      "fileSize": 120709
     },
     {
       "path": "mods/ImmediatelyFast-Fabric-1.6.6+1.21.1.jar",
@@ -186,23 +66,158 @@
       "fileSize": 228315
     },
     {
-      "path": "mods/ferritecore-7.0.2-hotfix-fabric.jar",
+      "path": "mods/ixeris-3.4.0+1.21.1-fabric.jar",
       "hashes": {
-        "sha1": "48ee764932d0c8ec81a2223dbe333886938e512c",
-        "sha512": "ca975bd3708cd96d30cf1447ac8883572113562eb2dd697e60c1cf382d6b70d0b1a511fcbfd042c51b2cf5d5ffc718b847f845e4c8a3e421e8c9ee741119a421"
+        "sha512": "f59d92a743998e0f59c9b8fd160dd3be6d5c210c073f0b02211b3c2a4358a850792970a1d426ce2319d18ab67de084802c4a7d61cca1c4f1555b1e893d196e0a",
+        "sha1": "b14de0084816dc86fb5dc2d2c9891c15849a5025"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/7fPcPGnb/ixeris-3.4.0%2B1.21.1-fabric.jar"
+      ],
+      "fileSize": 152349
+    },
+    {
+      "path": "mods/enhancedblockentities-0.10.2+1.21.jar",
+      "hashes": {
+        "sha1": "d81359d77fc7c5437f3e83e519dc2f869300f0cd",
+        "sha512": "60e01db603fcf1392c0cd5c3ce742e568f7d445d83fe60828b21f546e7d29fb6947231f22d28e29b07f4bdcb767b6dc2a2398b4decea665ecba1166690a44d49"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/OVuFYfre/versions/HBZAPs3u/enhancedblockentities-0.10.2%2B1.21.jar"
+      ],
+      "fileSize": 201157
+    },
+    {
+      "path": "mods/sodium-fabric-0.6.13+mc1.21.1.jar",
+      "hashes": {
+        "sha512": "13032e064c554fc8671573dadb07bc70e6ea2f68706c65c086c4feb1d2f664346a3414cbf9d1367b42b8d063a35e40f2f967ef9af31642e1f0093b852161fe91",
+        "sha1": "928a2598178c3a58b0638bab842f467d2e49251a"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/uXXizFIs/versions/bwKMSBhn/ferritecore-7.0.2-hotfix-fabric.jar"
+        "https://cdn.modrinth.com/data/AANobbMI/versions/u1OEbNKx/sodium-fabric-0.6.13%2Bmc1.21.1.jar"
       ],
-      "fileSize": 120709
+      "fileSize": 1297761
+    },
+    {
+      "path": "mods/noisium-fabric-2.3.0+mc1.21-1.21.1.jar",
+      "hashes": {
+        "sha512": "606ba78cf7f30d99e417c96aa042f600c1b626ed9c783919496d139de650013f1434fcf93545782e3889660322837ce6e85530d9e1a5cc20f9ad161357ede43e",
+        "sha1": "642a672cfc60ff1e1262a39d7e160b1381c5120c"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/KuNKN7d2/versions/4sGQgiu2/noisium-fabric-2.3.0%2Bmc1.21-1.21.1.jar"
+      ],
+      "fileSize": 216183
+    },
+    {
+      "path": "mods/BadOptimizations-2.3.0-1.21.1.jar",
+      "hashes": {
+        "sha512": "a9d78ab8d84d0ba3ebfd77eb3c4f585b9c3f0cad8e59b0ecef8c3ba107067342d7549f275c8fe45a5d4f35f7d848a15c184ad6e369044e659d17ce08afe91a77",
+        "sha1": "0d759c0996fbfc1ed4066170351722e6d9e52884"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/AQrpXs3f/BadOptimizations-2.3.0-1.21.1.jar"
+      ],
+      "fileSize": 123862
+    },
+    {
+      "path": "mods/fabric-api-0.116.4+1.21.1.jar",
+      "hashes": {
+        "sha1": "39d1a6b6213d012649821ecc516ed5b5142478ef",
+        "sha512": "95060def77b54ba6c6eb5af45b478ec6926f33f145d8f3933cd90cb2b6ab6913459d3d0afa3afcb01fca07d714628414a41ee8b6845261e88d92b83bfc668ad8"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/P7dR8mSH/versions/19viawBV/fabric-api-0.116.4%2B1.21.1.jar"
+      ],
+      "fileSize": 2423497
+    },
+    {
+      "path": "mods/modernfix-fabric-5.24.3+mc1.21.1.jar",
+      "hashes": {
+        "sha512": "43a81e63638387701edc49aabbde9e293890165e6e3b2df378aeabf56ea41fd666c1841cfac488e8d723ee99a673e09de4cc37a3e2141e04216f4aad5254dae1",
+        "sha1": "fd5bd05c9380243b3fa86e42b3649d8cdb235a60"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/nmDcB62a/versions/xDJFoW9U/modernfix-fabric-5.24.3%2Bmc1.21.1.jar"
+      ],
+      "fileSize": 460259
+    },
+    {
+      "path": "mods/cloth-config-15.0.140-fabric.jar",
+      "hashes": {
+        "sha512": "1b3f5db4fc1d481704053db9837d530919374bf7518d7cede607360f0348c04fc6347a3a72ccfef355559e1f4aef0b650cd58e5ee79c73b12ff0fc2746797a00",
+        "sha1": "5d82342a2df53fd6df712bfdd583a811572918a4"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/9s6osm5g/versions/HpMb5wGb/cloth-config-15.0.140-fabric.jar"
+      ],
+      "fileSize": 1157166
+    },
+    {
+      "path": "mods/moreculling-fabric-1.21.1-1.0.6.jar",
+      "hashes": {
+        "sha1": "e14150baf443abc24ee6236b837c287dd5950e95",
+        "sha512": "c6a6db1e2b63084457358171175ddf6061b32d31843f982001720c34433ae96cb13d72b910dc486ad1556e9db55352df3619f131c733bf843d3273d248989b05"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/51shyZVL/versions/1V6UtDhN/moreculling-fabric-1.21.1-1.0.6.jar"
+      ],
+      "fileSize": 345544
+    },
+    {
+      "path": "mods/lithium-fabric-0.15.0+mc1.21.1.jar",
+      "hashes": {
+        "sha1": "b7d77602807f2c7cd7132741244bf8c0b8dec6c1",
+        "sha512": "fd3215501ebe8f6590cdf1ccc58182873cad8d74ebc4b0b3a2f5724748b9cb04c2b967503c072311dfbca9ba856195dc4662f3395a071b294fa0acfdd2a86bf6"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/MM5BBBOK/lithium-fabric-0.15.0%2Bmc1.21.1.jar"
+      ],
+      "fileSize": 771768
     }
   ],
   "dependencies": {
-    "minecraft": "1.21.1",
-    "quilt-loader": "0.29.0"
+    "quilt-loader": "0.29.1",
+    "minecraft": "1.21.1"
   }
 }

--- a/Quilt/1.21.8/modrinth.index.json
+++ b/Quilt/1.21.8/modrinth.index.json
@@ -1,55 +1,10 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "0.1.2",
+  "versionId": "0.2.0",
   "name": "Photon",
   "summary": "",
   "files": [
-    {
-      "path": "mods/ImmediatelyFast-Fabric-1.12.1+1.21.8.jar",
-      "hashes": {
-        "sha512": "5277ba33c2f8255c65946a9e785a046d1c211aa974e679d881b9a259a50f42fc5f77a92d620a377d5992c66fa1ca581bb2fd902d1f93cdced4318fc2b10e45a8",
-        "sha1": "318608e466371772a4b0d2a6cd3fe86cf983e718"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/5ZwdcRci/versions/XxwOC2sk/ImmediatelyFast-Fabric-1.12.1%2B1.21.8.jar"
-      ],
-      "fileSize": 194728
-    },
-    {
-      "path": "mods/fabric-api-0.130.0+1.21.8.jar",
-      "hashes": {
-        "sha1": "5d8c74464535d569991dcdacf9bb61203c6cd73a",
-        "sha512": "27399d629d3fb955c8fc1e5e86cacb9b124814bb97ee7fe283336b0e28f5eb9ae31619814ab4aef70c5beea908d2a1ed5a8dd6b8641a53ecd50375d50067f061"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/P7dR8mSH/versions/zhzhM2yQ/fabric-api-0.130.0%2B1.21.8.jar"
-      ],
-      "fileSize": 2212919
-    },
-    {
-      "path": "mods/BadOptimizations-2.3.0-1.21.6-21.7.jar",
-      "hashes": {
-        "sha1": "6ca1457a183266af76099c382b926f56c7e5d007",
-        "sha512": "5d61b7c0946bef98bcda081f96d083bc6ae9c96e0de1ffe388406d9668a8878b2c3342465caa86270c9f33a6e00c42d5145718f8ce4a387025c2818581bdb6ce"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/Zkvk6pH6/BadOptimizations-2.3.0-1.21.6-21.7.jar"
-      ],
-      "fileSize": 123961
-    },
     {
       "path": "mods/cloth-config-19.0.147-fabric.jar",
       "hashes": {
@@ -64,6 +19,126 @@
         "https://cdn.modrinth.com/data/9s6osm5g/versions/cz0b1j8R/cloth-config-19.0.147-fabric.jar"
       ],
       "fileSize": 1149126
+    },
+    {
+      "path": "mods/ImmediatelyFast-Fabric-1.12.1+1.21.8.jar",
+      "hashes": {
+        "sha1": "318608e466371772a4b0d2a6cd3fe86cf983e718",
+        "sha512": "5277ba33c2f8255c65946a9e785a046d1c211aa974e679d881b9a259a50f42fc5f77a92d620a377d5992c66fa1ca581bb2fd902d1f93cdced4318fc2b10e45a8"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/5ZwdcRci/versions/XxwOC2sk/ImmediatelyFast-Fabric-1.12.1%2B1.21.8.jar"
+      ],
+      "fileSize": 194728
+    },
+    {
+      "path": "mods/c2me-fabric-mc1.21.8-0.3.4.0.0.jar",
+      "hashes": {
+        "sha512": "30cbc520cb8349036d55a1cb1f26964cf02410cf6d6a561d9cc07164d7566a3a7564367de62510f2bab50723c2c7c401718001153fa833560634ce4b2e212767",
+        "sha1": "0951ad76de856b2e8804f06efc4302f828dc3bff"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/VSNURh3q/versions/tlZRTK1v/c2me-fabric-mc1.21.8-0.3.4.0.0.jar"
+      ],
+      "fileSize": 4681084
+    },
+    {
+      "path": "mods/lithium-fabric-0.18.0+mc1.21.8.jar",
+      "hashes": {
+        "sha512": "6c69950760f48ef88f0c5871e61029b59af03ab5ed9b002b6a470d7adfdf26f0b875dcd360b664e897291002530981c20e0b2890fb889f29ecdaa007f885100f",
+        "sha1": "7c1a4af48ef242d59209052cc684afd089ed11bb"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/pDfTqezk/lithium-fabric-0.18.0%2Bmc1.21.8.jar"
+      ],
+      "fileSize": 792413
+    },
+    {
+      "path": "mods/moreculling-fabric-1.21.6-1.4.0-beta.1.jar",
+      "hashes": {
+        "sha512": "0f80c58b539c55c0b96a35b685694d8d74bf77f5dd9c63a7f811c17cf076ae26799b6411e941ff71d2f39b940262886fb3d66f78f239b7bb3558cce8c5447dac",
+        "sha1": "1e9b9ec184470aa5d52e0d968b5e87cf087efae2"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/51shyZVL/versions/ESxkwc6w/moreculling-fabric-1.21.6-1.4.0-beta.1.jar"
+      ],
+      "fileSize": 347230
+    },
+    {
+      "path": "mods/fabric-api-0.131.0+1.21.8.jar",
+      "hashes": {
+        "sha1": "c76a1cd624d8ad517f307ad0fc8484c4b3eabe97",
+        "sha512": "a4c7030d16eb012745b1ff3cb5487b08b88500259f5269a87815868ee686c02d5ba93cf2645de0f023f74c7cd78415c5be8938ce3d8fff24ccb1219ebb7a3a2b"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/P7dR8mSH/versions/ax9iQEs0/fabric-api-0.131.0%2B1.21.8.jar"
+      ],
+      "fileSize": 2224100
+    },
+    {
+      "path": "mods/BadOptimizations-2.3.0-1.21.6-21.7.jar",
+      "hashes": {
+        "sha1": "6ca1457a183266af76099c382b926f56c7e5d007",
+        "sha512": "5d61b7c0946bef98bcda081f96d083bc6ae9c96e0de1ffe388406d9668a8878b2c3342465caa86270c9f33a6e00c42d5145718f8ce4a387025c2818581bdb6ce"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/Zkvk6pH6/BadOptimizations-2.3.0-1.21.6-21.7.jar"
+      ],
+      "fileSize": 123961
+    },
+    {
+      "path": "mods/ixeris-3.4.0+1.21.8-fabric.jar",
+      "hashes": {
+        "sha1": "3f8cf2bed81858b647c5546f3bfff6bef45e951b",
+        "sha512": "cbedb022aea74831a53df5b468009d1c1b0bdb3e0d426a73f3f0570acfe7c9bf9c2d172e47fff35d23f4ef84ec6c58bc0455238ff6fb5a59fe6f4a6182088172"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/wOsMJPaE/ixeris-3.4.0%2B1.21.8-fabric.jar"
+      ],
+      "fileSize": 152330
+    },
+    {
+      "path": "mods/sodium-fabric-0.6.13+mc1.21.6.jar",
+      "hashes": {
+        "sha512": "ee97e3df07a6f734bc8a0f77c1f1de7f47bed09cf682f048ceb12675c51b70ba727b11fcacbb7b10cc9f79b283dd71a39751312b5c70568aa3ac9471407174db",
+        "sha1": "2d635c3d938aa3f75b0ec61c7402eeea2f9c30a9"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/AANobbMI/versions/ND4ROcMQ/sodium-fabric-0.6.13%2Bmc1.21.6.jar"
+      ],
+      "fileSize": 1443665
     },
     {
       "path": "mods/entityculling-fabric-1.8.2-mc1.21.6.jar",
@@ -81,94 +156,34 @@
       "fileSize": 473028
     },
     {
-      "path": "mods/c2me-fabric-mc1.21.8-0.3.4.0.0.jar",
+      "path": "mods/noisium-fabric-2.7.0+mc1.21.6.jar",
       "hashes": {
-        "sha1": "0951ad76de856b2e8804f06efc4302f828dc3bff",
-        "sha512": "30cbc520cb8349036d55a1cb1f26964cf02410cf6d6a561d9cc07164d7566a3a7564367de62510f2bab50723c2c7c401718001153fa833560634ce4b2e212767"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/VSNURh3q/versions/tlZRTK1v/c2me-fabric-mc1.21.8-0.3.4.0.0.jar"
-      ],
-      "fileSize": 4681084
-    },
-    {
-      "path": "mods/lithium-fabric-0.18.0+mc1.21.8.jar",
-      "hashes": {
-        "sha1": "7c1a4af48ef242d59209052cc684afd089ed11bb",
-        "sha512": "6c69950760f48ef88f0c5871e61029b59af03ab5ed9b002b6a470d7adfdf26f0b875dcd360b664e897291002530981c20e0b2890fb889f29ecdaa007f885100f"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/pDfTqezk/lithium-fabric-0.18.0%2Bmc1.21.8.jar"
-      ],
-      "fileSize": 792413
-    },
-    {
-      "path": "mods/sodium-fabric-0.6.13+mc1.21.6.jar",
-      "hashes": {
-        "sha1": "2d635c3d938aa3f75b0ec61c7402eeea2f9c30a9",
-        "sha512": "ee97e3df07a6f734bc8a0f77c1f1de7f47bed09cf682f048ceb12675c51b70ba727b11fcacbb7b10cc9f79b283dd71a39751312b5c70568aa3ac9471407174db"
+        "sha512": "80cc286f3a51b2d12304ef6a44f84c11d67cedec1a02fbaf59e2e816d9b5f0abd17cc6b5a0ca5880935e9dadfea3b951b790ee1e54300c009bc419c1c7451785",
+        "sha1": "e0a53dd0ccd5d1bc13798214e16f9f8a8521a335"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/AANobbMI/versions/ND4ROcMQ/sodium-fabric-0.6.13%2Bmc1.21.6.jar"
+        "https://cdn.modrinth.com/data/KuNKN7d2/versions/V9mMIy0f/noisium-fabric-2.7.0%2Bmc1.21.6.jar"
       ],
-      "fileSize": 1443665
+      "fileSize": 216078
     },
     {
       "path": "mods/ferritecore-8.0.0-fabric.jar",
       "hashes": {
-        "sha1": "53d76354587cd1965b842fdce7cff965b5c52fe5",
-        "sha512": "131b82d1d366f0966435bfcb38c362d604d68ecf30c106d31a6261bfc868ca3a82425bb3faebaa2e5ea17d8eed5c92843810eb2df4790f2f8b1e6c1bdc9b7745"
+        "sha512": "131b82d1d366f0966435bfcb38c362d604d68ecf30c106d31a6261bfc868ca3a82425bb3faebaa2e5ea17d8eed5c92843810eb2df4790f2f8b1e6c1bdc9b7745",
+        "sha1": "53d76354587cd1965b842fdce7cff965b5c52fe5"
       },
       "env": {
-        "client": "required",
-        "server": "required"
+        "server": "required",
+        "client": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/uXXizFIs/versions/CtMpt7Jr/ferritecore-8.0.0-fabric.jar"
       ],
       "fileSize": 79653
-    },
-    {
-      "path": "mods/moreculling-fabric-1.21.6-1.4.0-beta.1.jar",
-      "hashes": {
-        "sha1": "1e9b9ec184470aa5d52e0d968b5e87cf087efae2",
-        "sha512": "0f80c58b539c55c0b96a35b685694d8d74bf77f5dd9c63a7f811c17cf076ae26799b6411e941ff71d2f39b940262886fb3d66f78f239b7bb3558cce8c5447dac"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/51shyZVL/versions/ESxkwc6w/moreculling-fabric-1.21.6-1.4.0-beta.1.jar"
-      ],
-      "fileSize": 347230
-    },
-    {
-      "path": "mods/noisium-fabric-2.7.0+mc1.21.6.jar",
-      "hashes": {
-        "sha1": "e0a53dd0ccd5d1bc13798214e16f9f8a8521a335",
-        "sha512": "80cc286f3a51b2d12304ef6a44f84c11d67cedec1a02fbaf59e2e816d9b5f0abd17cc6b5a0ca5880935e9dadfea3b951b790ee1e54300c009bc419c1c7451785"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/KuNKN7d2/versions/V9mMIy0f/noisium-fabric-2.7.0%2Bmc1.21.6.jar"
-      ],
-      "fileSize": 216078
     }
   ],
   "dependencies": {


### PR DESCRIPTION
This pull request adds Ixeris (https://github.com/decce6/Ixeris) to Photon Fabric/Quilt 1.19.4, 1.20.1, 1.20.4, 1.21.1, and 1.21.8. Also updates the modlist to list Ixeris for said versions.

The mod off-threads event polling, allowing more CPU time for the render thread. Results in a smoother framerate when actively moving the camera.

Issues related to screen-flickering and reduced performance appear to have been resolved, making Ixeris stable for deployment in Photon.

Closes: #18