### PR TITLE
26.1.1 Support (Fabric)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -35,6 +35,7 @@ body:
     label: Minecraft Version
     description: What Minecraft version are you using Photon with?
     options:
+    - 26.1.1
     - 26.1
     - 1.21.11
     - 1.21.10

--- a/MODLIST.md
+++ b/MODLIST.md
@@ -9,6 +9,25 @@
     <summary><img src="assets/fabric-logo.png" style="vertical-align:middle; display:inline;">Fabric</summary>
     <div style="padding-left:1rem;">
     <details>
+        <summary>26.1.1 (Beta)</summary>
+        <ul>
+            <li><a href="https://modrinth.com/mod/badoptimizations">BadOptimizations</a> by <a href="https://modrinth.com/user/thosea">thosea</a></li>
+            <li><a href="https://modrinth.com/mod/cloth-config">Cloth Config API</a> by <a href="https://modrinth.com/user/shedaniel">shedaniel</a></li>
+            <li><a href="https://modrinth.com/mod/c2me-fabric">Concurrent Chunk Management Engine (Fabric)</a> by <a href="https://modrinth.com/user/ishland">ishland</a></li>
+            <li><a href="https://modrinth.com/mod/entityculling">Entity Culling</a> by <a href="https://modrinth.com/user/tr7zw">tr7zw</a></li>
+            <li><a href="https://modrinth.com/mod/fabric-api">Fabric API</a> by <a href="https://modrinth.com/user/modmuss50">modmuss50</a></li>
+            <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
+            <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
+            <li><a href="https://modrinth.com/mod/ixeris">Ixeris</a> by <a href="https://modrinth.com/user/decce6">decce6</a></li>
+            <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
+            <li><a href="https://modrinth.com/mod/modernfix-mvus">ModernFix-mVUS</a> by <a href="https://modrinth.com/user/Coredex">Coredex</a></li>
+            <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>
+            <li><a href="https://modrinth.com/mod/noisumforked">NoisiumForked</a> by <a href="https://modrinth.com/user/Coredex">Coredex</a></li>
+            <li><a href="https://modrinth.com/mod/scalablelux">ScalableLux</a> by <a href="https://modrinth.com/user/ishland">ishland</a></li>
+            <li><a href="https://modrinth.com/mod/sodium">Sodium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
+        </ul>
+    </details>
+    <details>
         <summary>26.1 (Beta)</summary>
         <ul>
             <li><a href="https://modrinth.com/mod/badoptimizations">BadOptimizations</a> by <a href="https://modrinth.com/user/thosea">thosea</a></li>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Photon
 
-Minecraft optimization framework prioritizing performance, simplicity, and compatibility. 1.7.10-26.1 across Fabric, Forge, NeoForge, and Quilt!
+Minecraft optimization framework prioritizing performance, simplicity, and compatibility. 1.7.10-26.1.1 across Fabric, Forge, NeoForge, and Quilt!
 
 [![PhotonMC](assets/github-link.svg)](https://github.com/RealWTBking/photon)
 [![Read the Wiki](assets/wiki-link.svg)](https://github.com/RealWTBking/photon/wiki)
@@ -17,7 +17,7 @@ Minecraft optimization framework prioritizing performance, simplicity, and compa
 
 </div>
 
-Photon is a client-side modpack that dramatically improves performance on Minecraft 1.7.10-26.1 across Fabric, Forge, NeoForge, and Quilt. Photon is deliberately built with simplicity and compatibility in mind. As a result, Photon can be used as a framework for building larger, content-focused modpacks.
+Photon is a client-side modpack that dramatically improves performance on Minecraft 1.7.10-26.1.1 across Fabric, Forge, NeoForge, and Quilt. Photon is deliberately built with simplicity and compatibility in mind. As a result, Photon can be used as a framework for building larger, content-focused modpacks.
 
 <!--Download-->
 ## Download
@@ -29,7 +29,8 @@ Photon is a client-side modpack that dramatically improves performance on Minecr
 
 | MC Version | Fabric | Forge | NeoForge | Quilt |
 |------------|:------:|:-----:|:--------:|:-----:|
-| 26.1       |   ✅  |   ❌  |    ✅   |   ✅  |
+| 26.1.1     |   ✅  |   ❌  |    ✅   |   ✅  |
+| 26.1       |   ⚠️  |   ❌  |    ❌   |   ❌  |
 | 1.21.11    |   ✅  |   ❌  |    ✅   |   ✅  |
 | 1.21.5-10  |   ⚠️  |   ❌  |    ⚠️   |   ⚠️  |
 | 1.21.4     |   ⚠️  |   ❌  |    ⚠️   |   ❌  |

--- a/export/Fabric/26.1.1/modrinth.index.json
+++ b/export/Fabric/26.1.1/modrinth.index.json
@@ -1,0 +1,223 @@
+{
+  "game": "minecraft",
+  "formatVersion": 1,
+  "versionId": "0.1.0",
+  "name": "Photon",
+  "summary": "",
+  "files": [
+    {
+      "path": "mods/Ixeris-4.1.8+26.1.1-fabric.jar",
+      "hashes": {
+        "sha512": "04f0a37d8c9373e5466b29dce9dab1690eb3988f3d3a807511d613fe8591651d2852e72e774e09c8fc5d6893842ecca33ec5a4676f53d7ae9a20eceee58c9cc0",
+        "sha1": "78f1acad0c34f072a0a3183b7d0f86a311f9b307"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/3zCbd4Se/Ixeris-4.1.8%2B26.1.1-fabric.jar"
+      ],
+      "fileSize": 690709
+    },
+    {
+      "path": "mods/ScalableLux-0.2.0+fabric.2b63825-all.jar",
+      "hashes": {
+        "sha1": "3875a697a9bb014c06aa3a62d72e8bec3de23160",
+        "sha512": "48565a4d8a1cbd623f0044086d971f2c0cf1c40e1d0b6636a61d41512f4c1c1ddff35879d9dba24b088a670ee254e2d5842d13a30b6d76df23706fa94ea4a58b"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/Ps1zyz6x/versions/gYbHVCz8/ScalableLux-0.2.0%2Bfabric.2b63825-all.jar"
+      ],
+      "fileSize": 183504
+    },
+    {
+      "path": "mods/modernfix-5.26.2-build.1.jar",
+      "hashes": {
+        "sha512": "fbef93c2dabf7bcd0ccd670226dfc4958f7ebe5d8c2b1158e88a65e6954a40f595efd58401d2a3dbb224660dca5952199cf64df29100e7bd39b1b1941290b57b",
+        "sha1": "d99980a3213293ade61f6cca109b8eeb87cc5a05"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/TjSm1wrD/versions/dqQ7mabN/modernfix-5.26.2-build.1.jar"
+      ],
+      "fileSize": 620901
+    },
+    {
+      "path": "mods/ferritecore-9.0.0-fabric.jar",
+      "hashes": {
+        "sha512": "d81fa97e11784c19d42f89c2f433831d007603dd7193cee45fa177e4a6a9c52b384b198586e04a0f7f63cd996fed713322578bde9a8db57e1188854ae5cbe584",
+        "sha1": "eac76ff0f3753422c61b2c44487d0d195d88d4bc"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/uXXizFIs/versions/d5ddUdiB/ferritecore-9.0.0-fabric.jar"
+      ],
+      "fileSize": 72677
+    },
+    {
+      "path": "mods/cloth-config-26.1.154.jar",
+      "hashes": {
+        "sha1": "832f9047bc4af13587709c74f7c37e1c8579d1eb",
+        "sha512": "8bfb75f2cac0a9910316c6a368a228c0f8f1261ac6f03dec5fba594e1619ac04334a3df4fb29778d61d0b8290d55949371a523d722b35501bf9a2902956d3b17"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/9s6osm5g/versions/GFM8zh9J/cloth-config-26.1.154.jar"
+      ],
+      "fileSize": 1135373
+    },
+    {
+      "path": "mods/noisium-fabric-2.8.4+mc26.1-pre-2.jar",
+      "hashes": {
+        "sha512": "757f3e4f5271f221a715df3c27c5da5f5c9612dbfba2a298cbda9381de1b832524ae676868839a6c93cb88612181a8ed5ab5f848e0fa768ac0750c1c38a88636",
+        "sha1": "3ca0f8a504a80dcd084a5c6f801beda50d67db08"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/hasdd01q/versions/QWyo5TsS/noisium-fabric-2.8.4%2Bmc26.1-pre-2.jar"
+      ],
+      "fileSize": 70336
+    },
+    {
+      "path": "mods/lithium-fabric-0.23.0+mc26.1.1.jar",
+      "hashes": {
+        "sha512": "9d7e92ea2af7d024cfe09bfc7eacf236e551da024f4ddeb3a20d88b01bc3620ee1c5a3355299c9dbfcc76406fb0b8e121a989651e6a73c8c2632290f84db8448",
+        "sha1": "4904811469a2f62d7de3e250b6c98acfa3b58d9f"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/kHXOBNih/lithium-fabric-0.23.0%2Bmc26.1.1.jar"
+      ],
+      "fileSize": 880954
+    },
+    {
+      "path": "mods/c2me-fabric-mc26.1.1-0.3.7+alpha.0.63.jar",
+      "hashes": {
+        "sha512": "d22e6acf2ba318046ce268c56cea586580ab217325e451b37b72f3213ceab95561c5a8dad4e3aec36a087a1096fa51bb81c670d64076395f38ad286a05ec4f22",
+        "sha1": "19f4bedeb5fbfe1be295c653288b4d38a7a84576"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/VSNURh3q/versions/wGnmDPvI/c2me-fabric-mc26.1.1-0.3.7%2Balpha.0.63.jar"
+      ],
+      "fileSize": 4728914
+    },
+    {
+      "path": "mods/fabric-api-0.145.4+26.1.2.jar",
+      "hashes": {
+        "sha1": "f6a5958eae1644ce8e8622b513bc6a795594675b",
+        "sha512": "ffd5ef62a745f76cd2e5481252cb7bc67006c809b4f436827d05ea22c01d19279e94a3b24df3d57e127af1cd08440b5de6a92a4ea8f39b2dcbbe1681275564c3"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/P7dR8mSH/versions/fm7UYECV/fabric-api-0.145.4%2B26.1.2.jar"
+      ],
+      "fileSize": 2408066
+    },
+    {
+      "path": "mods/entityculling-fabric-1.10.1-mc26.1.jar",
+      "hashes": {
+        "sha1": "17829d606ef5b73be4b206e5a465f8fb4e526fd5",
+        "sha512": "028bfa99f6eda39f78fa8b700a95d6b05c0349545560596176291efe69c3d0061642c7af5b8063e326e1b311de3b055e10efcae1ed254075baf2d91c6921c011"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/NNAgCjsB/versions/NaRJu6ah/entityculling-fabric-1.10.1-mc26.1.jar"
+      ],
+      "fileSize": 1563254
+    },
+    {
+      "path": "mods/ImmediatelyFast-Fabric-1.15.2+26.1.2.jar",
+      "hashes": {
+        "sha1": "195bc6059dda0aac574906d035fae0b62a575a87",
+        "sha512": "46371d0958d705182e0945a0bd93b750a07a1f32a4f3189d85741804392137a47790d3bd0e341e7e9d5bf2783652598575ae1dc26f188aa9a71758f9d568e709"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/5ZwdcRci/versions/lRuSLf0Y/ImmediatelyFast-Fabric-1.15.2%2B26.1.2.jar"
+      ],
+      "fileSize": 304946
+    },
+    {
+      "path": "mods/BadOptimizations-2.4.1-26.1-fabric.jar",
+      "hashes": {
+        "sha1": "9636073ca8f378ea796b5d13bffac146a7f2f0f3",
+        "sha512": "efba144dec306767da3aceb4b179e093daa60bc4c0ba6295d64c166092b8f62e4a4cc63a5bae76fb4c608f1dffa8ecd70c6884e48c804915e1b37ef042e31a99"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/gjIvugXc/BadOptimizations-2.4.1-26.1-fabric.jar"
+      ],
+      "fileSize": 61928
+    },
+    {
+      "path": "mods/sodium-fabric-0.8.9+mc26.1.1.jar",
+      "hashes": {
+        "sha1": "48b949ec71365788dfd4e89d489f7abd504aa709",
+        "sha512": "74f9dc8963b5258226837cc361ba6b525da734ab4fa5f05d1862bc6e9175f4fa81ca3d49443e2fb85be144d06042f0d65cbcceefc391043af857b38aa2614ae8"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/AANobbMI/versions/uGvVQBnw/sodium-fabric-0.8.9%2Bmc26.1.1.jar"
+      ],
+      "fileSize": 1810286
+    },
+    {
+      "path": "mods/moreculling-fabric-26.1.1-1.7.0-beta.5.jar",
+      "hashes": {
+        "sha512": "57556eb3280637c5666e0a4e93d8b92912848ba7804014d56f73e1363b3e1f7b272f5641cd08420123b9bf68ec9c5d71c2314ba3e4c5d69e5c4e00f0e925ddd8",
+        "sha1": "7831be27edaf8581c6bba15867b2a47f4ee9b625"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/51shyZVL/versions/KJBkanxk/moreculling-fabric-26.1.1-1.7.0-beta.5.jar"
+      ],
+      "fileSize": 358073
+    }
+  ],
+  "dependencies": {
+    "fabric-loader": "0.19.1",
+    "minecraft": "26.1.1"
+  }
+}

--- a/export/Fabric/26.1.1/overrides/config/c2me.toml
+++ b/export/Fabric/26.1.1/overrides/config/c2me.toml
@@ -1,0 +1,49 @@
+version = 3
+defaultGlobalExecutorParallelismExpression = "\tmax(\r\n\t\t1,\r\n\t\tmin(\r\n\t\t\tif( is_windows,\r\n\t\t\t\t(cpus / 1.6 - 2),\r\n\t\t\t\t(cpus / 1.2 - 2)\r\n\t\t\t),\r\n\t\t\tif( is_j9vm,\r\n\t\t\t\t( ( mem_gb - (if(is_client, 0.6, 0.2)) ) / 0.5 ),\r\n\t\t\t\t( ( mem_gb - (if(is_client, 1.2, 0.6)) ) / 1.2 )\r\n\t\t\t)\r\n\t\t) - if(is_client, 2, 0)\r\n\t)"
+globalExecutorParallelism = 1
+
+[clientSideConfig]
+
+	[clientSideConfig.modifyMaxVDConfig]
+		enabled = false
+		maxViewDistance = 32
+
+[fixes]
+	enforceSafeWorldRandomAccess = true
+
+[noTickViewDistance]
+	compatibilityMode = true
+	maxConcurrentChunkLoads = 2
+	ensureChunkCorrectness = false
+	enabled = true
+
+[generalOptimizations]
+	midTickChunkTasksInterval = 100000
+	optimizeAsyncChunkRequest = false
+
+	[generalOptimizations.autoSave]
+		mode = "ENHANCED"
+		delay = 30000
+
+[ioSystem]
+	async = true
+	# -1 for Vanilla default  
+	# 1  for GZip (RFC1952) (Vanilla compatible) 
+	# 2  for Zlib (RFC1950) (Vanilla default) (Vanilla compatible) 
+	# 3  for Uncompressed (Fastest, but higher disk usage) (Vanilla compatible) 
+	chunkStreamVersion = 2
+	gcFreeChunkSerializer = false
+	replaceImpl = false
+	chunkDataCacheSoftLimit = 8192
+	chunkDataCacheLimit = 32678
+
+[threadedWorldGen]
+	allowThreadedFeatures = false
+	reduceLockRadius = false
+	asyncScheduling = false
+	enabled = "false"
+
+[vanillaWorldGenOptimizations]
+	optimizeAquifer = false
+	useEndBiomeCache = false
+

--- a/export/Fabric/26.1.1/overrides/config/entityculling.json
+++ b/export/Fabric/26.1.1/overrides/config/entityculling.json
@@ -1,0 +1,38 @@
+{
+  "configVersion": 6,
+  "renderNametagsThroughWalls": true,
+  "blockEntityWhitelist": [
+    "create:rope_pulley",
+    "botania:flame_ring",
+    "minecraft:beacon",
+    "create:hose_pulley",
+    "betterend:eternal_pedestal",
+    "botania:magic_missile",
+    "botania:falling_star"
+  ],
+  "entityWhitelist": [
+    "botania:mana_burst",
+    "drg_flares:drg_flares"
+  ],
+  "tracingDistance": 128,
+  "debugMode": false,
+  "sleepDelay": 10,
+  "hitboxLimit": 50,
+  "skipMarkerArmorStands": true,
+  "tickCulling": true,
+  "tickCullingWhitelist": [
+    "create:contraption",
+    "create:stationary_contraption",
+    "create:gantry_contraption",
+    "minecraft:boat",
+    "mts:builder_seat",
+    "minecraft:firework_rocket",
+    "create:carriage_contraption",
+    "mts:builder_rendering",
+    "drg_flares:drg_flares",
+    "mts:builder_existing"
+  ],
+  "disableF3": true,
+  "skipEntityCulling": false,
+  "skipBlockEntityCulling": false
+}

--- a/export/Fabric/26.1.1/overrides/config/fabric_loader_dependencies.json
+++ b/export/Fabric/26.1.1/overrides/config/fabric_loader_dependencies.json
@@ -1,0 +1,10 @@
+{
+	"version": 1,
+	"overrides": {
+		"badoptimizations": {
+			"depends": {
+				"minecraft": "26.1.1"
+			}
+		}
+	}
+}

--- a/export/Fabric/26.1.1/overrides/config/ferritecore.mixin.properties
+++ b/export/Fabric/26.1.1/overrides/config/ferritecore.mixin.properties
@@ -1,0 +1,11 @@
+replaceNeighborLookup = true
+replacePropertyMap = true
+cacheMultipartPredicates = true
+modelResourceLocations = true
+multipartDeduplication = true
+blockstateCacheDeduplication = true
+bakedQuadDeduplication = true
+modelSides = true
+useSmallThreadingDetector = false
+compactFastMap = false
+populateNeighborTable = true

--- a/export/Fabric/26.1.1/overrides/config/immediatelyfast.json
+++ b/export/Fabric/26.1.1/overrides/config/immediatelyfast.json
@@ -1,0 +1,21 @@
+{
+  "REGULAR_INFO": "----- Regular config values below -----",
+  "font_atlas_resizing": true,
+  "map_atlas_generation": true,
+  "hud_batching": true,
+  "fast_text_lookup": true,
+  "fast_buffer_upload": true,
+  "COSMETIC_INFO": "----- Cosmetic only config values below (Does not optimize anything) -----",
+  "dont_add_info_into_debug_hud": false,
+  "EXPERIMENTAL_INFO": "----- Experimental config values below (Rendering glitches may occur) -----",
+  "experimental_disable_error_checking": false,
+  "experimental_disable_resource_pack_conflict_handling": false,
+  "experimental_sign_text_buffering": false,
+  "experimental_screen_batching": false,
+  "DEBUG_INFO": "----- Debug only config values below (Do not touch) -----",
+  "debug_only_and_not_recommended_disable_universal_batching": false,
+  "debug_only_and_not_recommended_disable_mod_conflict_handling": false,
+  "debug_only_and_not_recommended_disable_hardware_conflict_handling": false,
+  "debug_only_print_additional_error_information": false,
+  "debug_only_use_last_usage_for_batch_ordering": false
+}

--- a/export/Fabric/26.1.1/overrides/config/moreculling.toml
+++ b/export/Fabric/26.1.1/overrides/config/moreculling.toml
@@ -1,0 +1,23 @@
+version = 1
+enableSodiumMenu = true
+cloudCulling = true
+signTextCulling = true
+rainCulling = true
+useBlockStateCulling = true
+useCustomItemFrameRenderer = true
+itemFrameMapCulling = true
+useItemFrameLOD = true
+itemFrameLODRange = 80
+useItemFrame3FaceCulling = true
+itemFrame3FaceCullingRange = 12.0
+leavesCullingMode = "DEFAULT"
+leavesCullingAmount = 2
+includeMangroveRoots = true
+powderSnowCulling = true
+endGatewayCulling = true
+beaconBeamCulling = true
+entityModelCulling = false
+useOnModdedBlocksByDefault = true
+
+[modCompatibility]
+minecraft = true

--- a/export/Fabric/26.1.1/overrides/config/sodium-options.json
+++ b/export/Fabric/26.1.1/overrides/config/sodium-options.json
@@ -1,0 +1,26 @@
+{
+  "quality": {
+    "weather_quality": "DEFAULT",
+    "leaves_quality": "DEFAULT",
+    "enable_vignette": true
+  },
+  "advanced": {
+    "enable_memory_tracing": false,
+    "use_advanced_staging_buffers": true,
+    "cpu_render_ahead_limit": 3
+  },
+  "performance": {
+    "chunk_builder_threads": 0,
+    "always_defer_chunk_updates_v2": false,
+    "animate_only_visible_textures": true,
+    "use_entity_culling": false,
+    "use_fog_occlusion": true,
+    "use_block_face_culling": true,
+    "use_no_error_g_l_context": true,
+    "sorting_enabled_v2": true
+  },
+  "notifications": {
+    "has_cleared_donation_button": false,
+    "has_seen_donation_prompt": false
+  }
+}


### PR DESCRIPTION
Initial MC 26.1.1 Beta release for Fabric. Updated the README, MODLIST, and Bug Report issue template to address MC 26.1.1. Quilt and NeoForge 26.1.1 will be supported when they are more stable.

#38