### PR TITLE
Add Fast Noise

### DIFF
--- a/MODLIST.md
+++ b/MODLIST.md
@@ -16,13 +16,13 @@
             <li><a href="https://modrinth.com/mod/c2me-fabric">Concurrent Chunk Management Engine (Fabric)</a> by <a href="https://modrinth.com/user/ishland">ishland</a></li>
             <li><a href="https://modrinth.com/mod/entityculling">Entity Culling</a> by <a href="https://modrinth.com/user/tr7zw">tr7zw</a></li>
             <li><a href="https://modrinth.com/mod/fabric-api">Fabric API</a> by <a href="https://modrinth.com/user/modmuss50">modmuss50</a></li>
+            <li><a href="https://modrinth.com/mod/zfastnoise">Fast Noise</a> by <a href="https://modrinth.com/user/ZenXArch">ZenXArch</a></li>
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
             <li><a href="https://modrinth.com/mod/ixeris">Ixeris</a> by <a href="https://modrinth.com/user/decce6">decce6</a></li>
             <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
             <li><a href="https://modrinth.com/mod/modernfix-mvus">ModernFix-mVUS</a> by <a href="https://modrinth.com/user/Coredex">Coredex</a></li>
             <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>
-            <li><a href="https://modrinth.com/mod/noisumforked">NoisiumForked</a> by <a href="https://modrinth.com/user/Coredex">Coredex</a></li>
             <li><a href="https://modrinth.com/mod/scalablelux">ScalableLux</a> by <a href="https://modrinth.com/user/ishland">ishland</a></li>
             <li><a href="https://modrinth.com/mod/sodium">Sodium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
         </ul>
@@ -72,13 +72,13 @@
             <li><a href="https://modrinth.com/mod/c2me-fabric">Concurrent Chunk Management Engine (Fabric)</a> by <a href="https://modrinth.com/user/ishland">ishland</a></li>
             <li><a href="https://modrinth.com/mod/entityculling">Entity Culling</a> by <a href="https://modrinth.com/user/tr7zw">tr7zw</a></li>
             <li><a href="https://modrinth.com/mod/fabric-api">Fabric API</a> by <a href="https://modrinth.com/user/modmuss50">modmuss50</a></li>
+            <li><a href="https://modrinth.com/mod/zfastnoise">Fast Noise</a> by <a href="https://modrinth.com/user/ZenXArch">ZenXArch</a></li>
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
             <li><a href="https://modrinth.com/mod/ixeris">Ixeris</a> by <a href="https://modrinth.com/user/decce6">decce6</a></li>
             <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
             <li><a href="https://modrinth.com/mod/modernfix-mvus">ModernFix-mVUS</a> by <a href="https://modrinth.com/user/Coredex">Coredex</a></li>
             <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>
-            <li><a href="https://modrinth.com/mod/noisumforked">NoisiumForked</a> by <a href="https://modrinth.com/user/Coredex">Coredex</a></li>
             <li><a href="https://modrinth.com/mod/scalablelux">ScalableLux</a> by <a href="https://modrinth.com/user/ishland">ishland</a></li>
             <li><a href="https://modrinth.com/mod/sodium">Sodium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
         </ul>
@@ -196,13 +196,13 @@
             <li><a href="https://modrinth.com/mod/ebe">Enhanced Block Entities</a> by <a href="https://modrinth.com/user/FoundationGames">Foundation Games</a></li>
             <li><a href="https://modrinth.com/mod/entityculling">Entity Culling</a> by <a href="https://modrinth.com/user/tr7zw">tr7zw</a></li>
             <li><a href="https://modrinth.com/mod/fabric-api">Fabric API</a> by <a href="https://modrinth.com/user/modmuss50">modmuss50</a></li>
+            <li><a href="https://modrinth.com/mod/zfastnoise">Fast Noise</a> by <a href="https://modrinth.com/user/ZenXArch">ZenXArch</a></li>
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
             <li><a href="https://modrinth.com/mod/ixeris">Ixeris</a> by <a href="https://modrinth.com/user/decce6">decce6</a></li>
             <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
             <li><a href="https://modrinth.com/mod/modernfix">ModernFix</a> by <a href="https://modrinth.com/user/embeddedt">embeddedt</a></li>
             <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>
-            <li><a href="https://modrinth.com/mod/noisium">Noisium</a> by <a href="https://modrinth.com/user/Steveplays">Steveplays</a></li>
             <li><a href="https://modrinth.com/mod/scalablelux">ScalableLux</a> by <a href="https://modrinth.com/user/ishland">ishland</a></li>
             <li><a href="https://modrinth.com/mod/sodium">Sodium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
         </ul>
@@ -235,6 +235,7 @@
             <li><a href="https://modrinth.com/mod/ebe">Enhanced Block Entities</a> by <a href="https://modrinth.com/user/FoundationGames">Foundation Games</a></li>
             <li><a href="https://modrinth.com/mod/entityculling">Entity Culling</a> by <a href="https://modrinth.com/user/tr7zw">tr7zw</a></li>
             <li><a href="https://modrinth.com/mod/fabric-api">Fabric API</a> by <a href="https://modrinth.com/user/modmuss50">modmuss50</a></li>
+            <li><a href="https://modrinth.com/mod/zfastnoise">Fast Noise</a> by <a href="https://modrinth.com/user/ZenXArch">ZenXArch</a></li>
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
             <li><a href="https://modrinth.com/mod/indium">Indium</a> by <a href="https://modrinth.com/user/comp500">comp500</a></li>
@@ -242,7 +243,6 @@
             <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
             <li><a href="https://modrinth.com/mod/modernfix">ModernFix</a> by <a href="https://modrinth.com/user/embeddedt">embeddedt</a></li>
             <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>
-            <li><a href="https://modrinth.com/mod/noisium">Noisium</a> by <a href="https://modrinth.com/user/Steveplays">Steveplays</a></li>
             <li><a href="https://modrinth.com/mod/sodium">Sodium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
         </ul>
     </details>
@@ -255,6 +255,7 @@
             <li><a href="https://modrinth.com/mod/ebe">Enhanced Block Entities</a> by <a href="https://modrinth.com/user/FoundationGames">Foundation Games</a></li>
             <li><a href="https://modrinth.com/mod/entityculling">Entity Culling</a> by <a href="https://modrinth.com/user/tr7zw">tr7zw</a></li>
             <li><a href="https://modrinth.com/mod/fabric-api">Fabric API</a> by <a href="https://modrinth.com/user/modmuss50">modmuss50</a></li>
+            <li><a href="https://modrinth.com/mod/zfastnoise">Fast Noise</a> by <a href="https://modrinth.com/user/ZenXArch">ZenXArch</a></li>
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
             <li><a href="https://modrinth.com/mod/indium">Indium</a> by <a href="https://modrinth.com/user/comp500">comp500</a></li>
@@ -262,7 +263,6 @@
             <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
             <li><a href="https://modrinth.com/mod/modernfix">ModernFix</a> by <a href="https://modrinth.com/user/embeddedt">embeddedt</a></li>
             <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>
-            <li><a href="https://modrinth.com/mod/noisium">Noisium</a> by <a href="https://modrinth.com/user/Steveplays">Steveplays</a></li>
             <li><a href="https://modrinth.com/mod/sodium">Sodium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
         </ul>
     </details>
@@ -275,6 +275,7 @@
             <li><a href="https://modrinth.com/mod/ebe">Enhanced Block Entities</a> by <a href="https://modrinth.com/user/FoundationGames">Foundation Games</a></li>
             <li><a href="https://modrinth.com/mod/entityculling">Entity Culling</a> by <a href="https://modrinth.com/user/tr7zw">tr7zw</a></li>
             <li><a href="https://modrinth.com/mod/fabric-api">Fabric API</a> by <a href="https://modrinth.com/user/modmuss50">modmuss50</a></li>
+            <li><a href="https://modrinth.com/mod/zfastnoise">Fast Noise</a> by <a href="https://modrinth.com/user/ZenXArch">ZenXArch</a></li>
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
             <li><a href="https://modrinth.com/mod/indium">Indium</a> by <a href="https://modrinth.com/user/comp500">comp500</a></li>
@@ -584,6 +585,7 @@
             <li><a href="https://modrinth.com/mod/badoptimizations">BadOptimizations</a> by <a href="https://modrinth.com/user/thosea">thosea</a></li>
             <li><a href="https://modrinth.com/mod/cloth-config">Cloth Config API</a> by <a href="https://modrinth.com/user/shedaniel">shedaniel</a></li>
             <li><a href="https://modrinth.com/mod/c2me-neoforge">Concurrent Chunk Management Engine (NeoForge)</a> by <a href="https://modrinth.com/user/ishland">ishland</a></li>
+            <li><a href="https://modrinth.com/mod/zfastnoise">Fast Noise</a> by <a href="https://modrinth.com/user/ZenXArch">ZenXArch</a></li>
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
             <li><a href="https://modrinth.com/mod/ixeris">Ixeris</a> by <a href="https://modrinth.com/user/decce6">decce6</a></li>
@@ -775,13 +777,13 @@
             <li><a href="https://modrinth.com/mod/c2me-fabric">Concurrent Chunk Management Engine (Fabric)</a> by <a href="https://modrinth.com/user/ishland">ishland</a></li>
             <li><a href="https://modrinth.com/mod/entityculling">Entity Culling</a> by <a href="https://modrinth.com/user/tr7zw">tr7zw</a></li>
             <li><a href="https://modrinth.com/mod/fabric-api">Fabric API</a> by <a href="https://modrinth.com/user/modmuss50">modmuss50</a></li>
+            <li><a href="https://modrinth.com/mod/zfastnoise">Fast Noise</a> by <a href="https://modrinth.com/user/ZenXArch">ZenXArch</a></li>
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
             <li><a href="https://modrinth.com/mod/ixeris">Ixeris</a> by <a href="https://modrinth.com/user/decce6">decce6</a></li>
             <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
             <li><a href="https://modrinth.com/mod/modernfix-mvus">ModernFix-mVUS</a> by <a href="https://modrinth.com/user/Coredex">Coredex</a></li>
             <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>
-            <li><a href="https://modrinth.com/mod/noisumforked">NoisiumForked</a> by <a href="https://modrinth.com/user/Coredex">Coredex</a></li>
             <li><a href="https://modrinth.com/mod/scalablelux">ScalableLux</a> by <a href="https://modrinth.com/user/ishland">ishland</a></li>
             <li><a href="https://modrinth.com/mod/sodium">Sodium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
         </ul>
@@ -881,13 +883,13 @@
             <li><a href="https://modrinth.com/mod/ebe">Enhanced Block Entities</a> by <a href="https://modrinth.com/user/FoundationGames">Foundation Games</a></li>
             <li><a href="https://modrinth.com/mod/entityculling">Entity Culling</a> by <a href="https://modrinth.com/user/tr7zw">tr7zw</a></li>
             <li><a href="https://modrinth.com/mod/fabric-api">Fabric API</a> by <a href="https://modrinth.com/user/modmuss50">modmuss50</a></li>
+            <li><a href="https://modrinth.com/mod/zfastnoise">Fast Noise</a> by <a href="https://modrinth.com/user/ZenXArch">ZenXArch</a></li>
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
             <li><a href="https://modrinth.com/mod/ixeris">Ixeris</a> by <a href="https://modrinth.com/user/decce6">decce6</a></li>
             <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
             <li><a href="https://modrinth.com/mod/modernfix">ModernFix</a> by <a href="https://modrinth.com/user/embeddedt">embeddedt</a></li>
             <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>
-            <li><a href="https://modrinth.com/mod/noisium">Noisium</a> by <a href="https://modrinth.com/user/Steveplays">Steveplays</a></li>
             <li><a href="https://modrinth.com/mod/scalablelux">ScalableLux</a> by <a href="https://modrinth.com/user/ishland">ishland</a></li>
             <li><a href="https://modrinth.com/mod/sodium">Sodium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
         </ul>
@@ -919,6 +921,7 @@
             <li><a href="https://modrinth.com/mod/c2me-fabric">Concurrent Chunk Management Engine (Fabric)</a> by <a href="https://modrinth.com/user/ishland">ishland</a></li>
             <li><a href="https://modrinth.com/mod/ebe">Enhanced Block Entities</a> by <a href="https://modrinth.com/user/FoundationGames">Foundation Games</a></li>
             <li><a href="https://modrinth.com/mod/entityculling">Entity Culling</a> by <a href="https://modrinth.com/user/tr7zw">tr7zw</a></li>
+            <li><a href="https://modrinth.com/mod/zfastnoise">Fast Noise</a> by <a href="https://modrinth.com/user/ZenXArch">ZenXArch</a></li>
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
             <li><a href="https://modrinth.com/mod/indium">Indium</a> by <a href="https://modrinth.com/user/comp500">comp500</a></li>
@@ -926,7 +929,6 @@
             <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
             <li><a href="https://modrinth.com/mod/modernfix">ModernFix</a> by <a href="https://modrinth.com/user/embeddedt">embeddedt</a></li>
             <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>
-            <li><a href="https://modrinth.com/mod/noisium">Noisium</a> by <a href="https://modrinth.com/user/Steveplays">Steveplays</a></li>
             <li><a href="https://modrinth.com/mod/qsl">Quilted Fabric API (QFAPI) / Quilt Standard Libraries (QSL)</a> by <a href="https://modrinth.com/organization/quiltmc">QuiltMC</a></li>
             <li><a href="https://modrinth.com/mod/sodium">Sodium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
         </ul>
@@ -939,6 +941,7 @@
             <li><a href="https://modrinth.com/mod/c2me-fabric">Concurrent Chunk Management Engine (Fabric)</a> by <a href="https://modrinth.com/user/ishland">ishland</a></li>
             <li><a href="https://modrinth.com/mod/ebe">Enhanced Block Entities</a> by <a href="https://modrinth.com/user/FoundationGames">Foundation Games</a></li>
             <li><a href="https://modrinth.com/mod/entityculling">Entity Culling</a> by <a href="https://modrinth.com/user/tr7zw">tr7zw</a></li>
+            <li><a href="https://modrinth.com/mod/zfastnoise">Fast Noise</a> by <a href="https://modrinth.com/user/ZenXArch">ZenXArch</a></li>
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
             <li><a href="https://modrinth.com/mod/indium">Indium</a> by <a href="https://modrinth.com/user/comp500">comp500</a></li>
@@ -946,7 +949,6 @@
             <li><a href="https://modrinth.com/mod/lithium">Lithium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
             <li><a href="https://modrinth.com/mod/modernfix">ModernFix</a> by <a href="https://modrinth.com/user/embeddedt">embeddedt</a></li>
             <li><a href="https://modrinth.com/mod/moreculling">More Culling</a> by <a href="https://modrinth.com/user/FX">FX</a></li>
-            <li><a href="https://modrinth.com/mod/noisium">Noisium</a> by <a href="https://modrinth.com/user/Steveplays">Steveplays</a></li>
             <li><a href="https://modrinth.com/mod/qsl">Quilted Fabric API (QFAPI) / Quilt Standard Libraries (QSL)</a> by <a href="https://modrinth.com/organization/quiltmc">QuiltMC</a></li>
             <li><a href="https://modrinth.com/mod/sodium">Sodium</a> by <a href="https://modrinth.com/user/jellysquid3">jellysquid3</a></li>
         </ul>
@@ -959,6 +961,7 @@
             <li><a href="https://modrinth.com/mod/c2me-fabric">Concurrent Chunk Management Engine (Fabric)</a> by <a href="https://modrinth.com/user/ishland">ishland</a></li>
             <li><a href="https://modrinth.com/mod/ebe">Enhanced Block Entities</a> by <a href="https://modrinth.com/user/FoundationGames">Foundation Games</a></li>
             <li><a href="https://modrinth.com/mod/entityculling">Entity Culling</a> by <a href="https://modrinth.com/user/tr7zw">tr7zw</a></li>
+            <li><a href="https://modrinth.com/mod/zfastnoise">Fast Noise</a> by <a href="https://modrinth.com/user/ZenXArch">ZenXArch</a></li>
             <li><a href="https://modrinth.com/mod/ferrite-core">FerriteCore</a> by <a href="https://modrinth.com/user/malte0811">malte0811</a></li>
             <li><a href="https://modrinth.com/mod/immediatelyfast">ImmediatelyFast</a> by <a href="https://modrinth.com/user/RaphiMC">RaphiMC</a></li>
             <li><a href="https://modrinth.com/mod/indium">Indium</a> by <a href="https://modrinth.com/user/comp500">comp500</a></li>

--- a/export/Fabric/1.19.4/modrinth.index.json
+++ b/export/Fabric/1.19.4/modrinth.index.json
@@ -1,84 +1,54 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "1.1.13",
+  "versionId": "1.2.0",
   "name": "Photon",
   "summary": "",
   "files": [
     {
-      "path": "mods/sodium-fabric-mc1.19.4-0.4.10+build.24.jar",
+      "path": "mods/c2me-fabric-mc1.19.4-0.2.0+alpha.10.66.jar",
       "hashes": {
-        "sha1": "b060680929d7a6d130fb980a9f9907461df05fa1",
-        "sha512": "61562626870aa4067657d2687d1fce80fb7d62af32fd68a22708e24ee5b84b39d16b26ccf4db8f53f2da42ba1916d6a5e11efc476cb5c2a8644207659fd5dfef"
+        "sha1": "5c681eb7358d91faf52c7b57d590c4fa274a6847",
+        "sha512": "1cbb1fe9b3538d953e341b499c67001f9fb142bf24853a6133dbc091aa8757d47d9949a1bc04106676cfb0b3ac280409fe017c1e3d4194bf35bb606eaea6c79d"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/AANobbMI/versions/b4hTi3mo/sodium-fabric-mc1.19.4-0.4.10%2Bbuild.24.jar"
+        "https://cdn.modrinth.com/data/VSNURh3q/versions/uZ1nQtIu/c2me-fabric-mc1.19.4-0.2.0%2Balpha.10.66.jar"
       ],
-      "fileSize": 711302
+      "fileSize": 1298898
     },
     {
-      "path": "mods/phosphor-fabric-mc1.19.x-0.8.1.jar",
+      "path": "mods/enhancedblockentities-0.9+1.19.4.jar",
       "hashes": {
-        "sha512": "13a0707b7a92726aa3154bc40978f36bb340d643c1d60e9fa2cbf8f7b0c7d3ea03c2a079f46a487df05e944eec9f5779afae9e99be7f70373e8a31d59948d487",
-        "sha1": "2dd6f771ba5878d81892b9487f35340e94c87a1c"
+        "sha1": "97ffe54d7f5294fe6c8b529f51ef4b208b3ab1a7",
+        "sha512": "a60cbef0fc67789fafefafaf799107e17b96a2d1cf67f3b8396f8960a64308c9a9d33c822a0d62f6873bf2215c2026c46b78fa2d240c0055148230f13903636d"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/hEOCdOgW/versions/mc1.19.x-0.8.1/phosphor-fabric-mc1.19.x-0.8.1.jar"
+        "https://cdn.modrinth.com/data/OVuFYfre/versions/Xdo5ZiRc/enhancedblockentities-0.9%2B1.19.4.jar"
       ],
-      "fileSize": 88018
+      "fileSize": 492518
     },
     {
-      "path": "mods/indium-1.0.19+mc1.19.4.jar",
+      "path": "mods/Ixeris-4.1.10+1.20.1-fabric.jar",
       "hashes": {
-        "sha1": "55638e279d8a19ea5df67ff86feb6350e95376e1",
-        "sha512": "676e217ba05ff49c3e8d5d801f7c157b5b988eb21a44694d5c72a279dcdfe30933f57639a66d9f49b9b10c26edb288e8aa212ba27d4bd9abe0212c52b2e9b193"
+        "sha1": "e477095f3c09758623a729fd1ca439cac180016c",
+        "sha512": "1d0f35e45d3d10d1d6d5a1df18ade64be36c6aa7dfc3626175dec6c78e54129e8fc31f7b7c02ebcafeafba683835ab2bca4d7908f74b00060c1eb660d7c0d8e4"
       },
       "env": {
-        "client": "required",
-        "server": "required"
+        "server": "required",
+        "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/Orvt0mRa/versions/oYQsfz9e/indium-1.0.19%2Bmc1.19.4.jar"
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/oBuFEwH4/Ixeris-4.1.10%2B1.20.1-fabric.jar"
       ],
-      "fileSize": 104841
-    },
-    {
-      "path": "mods/modernfix-fabric-5.7.2+mc1.19.4.jar",
-      "hashes": {
-        "sha512": "94877c4253224855753650e198df5cec908e4d07ae8f678982fa0a51a421d8f5659c2d505320a6af079da890bddca4f17d519484411bba877ca67fe545ec58b8",
-        "sha1": "53ec153757699d3998f74891d8ac8ef13b3da2aa"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/nmDcB62a/versions/LXlsO4Vo/modernfix-fabric-5.7.2%2Bmc1.19.4.jar"
-      ],
-      "fileSize": 513020
-    },
-    {
-      "path": "mods/ferritecore-5.2.0-fabric.jar",
-      "hashes": {
-        "sha1": "ed6fa9a9365d4e58db6703479a44cc6aed5add2f",
-        "sha512": "56a4ac2ed002260ee451fa9d33169ddcd01473bf46eee97061666b13fa386cd23e15238a72729e55f32d81cce8ae049c80caabf1947ba998258282226289be0c"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/uXXizFIs/versions/RbR7EG8T/ferritecore-5.2.0-fabric.jar"
-      ],
-      "fileSize": 124924
+      "fileSize": 704470
     },
     {
       "path": "mods/cloth-config-10.1.135-fabric.jar",
@@ -96,19 +66,124 @@
       "fileSize": 1171035
     },
     {
-      "path": "mods/fabric-api-0.87.2+1.19.4.jar",
+      "path": "mods/moreculling-1.19.4-0.17.0.jar",
       "hashes": {
-        "sha1": "586ac174c831da9fd35edce1e36eb14c7f878ce3",
-        "sha512": "d839c678699130db605ac580484b5193c302dfa1ed91014c138cb1354874cef0d16580c7c11bedece3cf8a027ddbb4755d4924f6045970a6af608ff0fed898eb"
+        "sha1": "91d4fdb4786d2dfe56a84dff552bcadbebc88cec",
+        "sha512": "bf01675be88b4770f6fa6197644978912e9d3fd547c8eeeb709102088a15b0570043f5b05c93f7d600a08ff80dad1f00b3fd52f2fb1243f9268b837e6329be52"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
+        "https://cdn.modrinth.com/data/51shyZVL/versions/A9LKf67q/moreculling-1.19.4-0.17.0.jar"
+      ],
+      "fileSize": 1235479
+    },
+    {
+      "path": "mods/fabric-api-0.87.2+1.19.4.jar",
+      "hashes": {
+        "sha512": "d839c678699130db605ac580484b5193c302dfa1ed91014c138cb1354874cef0d16580c7c11bedece3cf8a027ddbb4755d4924f6045970a6af608ff0fed898eb",
+        "sha1": "586ac174c831da9fd35edce1e36eb14c7f878ce3"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
         "https://cdn.modrinth.com/data/P7dR8mSH/versions/nyAmoHlr/fabric-api-0.87.2%2B1.19.4.jar"
       ],
       "fileSize": 2055860
+    },
+    {
+      "path": "mods/ImmediatelyFast-Fabric-1.2.11+1.19.4.jar",
+      "hashes": {
+        "sha1": "956a23c27590dd14195128708cd6e59b057a10dc",
+        "sha512": "c7b3443406357bad283d2214f4f99ff8760a60c60c228b2e40acc33e37409be87c3e7eebd4d33f460dd2697a25188361f8869a96e5cb2d34422a6107248d2e85"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/5ZwdcRci/versions/ezKTj0NE/ImmediatelyFast-Fabric-1.2.11%2B1.19.4.jar"
+      ],
+      "fileSize": 370128
+    },
+    {
+      "path": "mods/zfastnoise-1.0.11+1.19.4.jar",
+      "hashes": {
+        "sha512": "4f3a78109274959171db0504a39301fa492c90b34665be047fac4478922f18c23cef07eed5cdbf8de886d5022f4bf7ebdf951930d2b83e6c1ed8ba5a710dfc30",
+        "sha1": "9ea0bfbc3c222cb04aa65e5a67473922f8d69058"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/OnlVIpq5/versions/ih5xzhim/zfastnoise-1.0.11%2B1.19.4.jar"
+      ],
+      "fileSize": 34592
+    },
+    {
+      "path": "mods/modernfix-fabric-5.7.2+mc1.19.4.jar",
+      "hashes": {
+        "sha1": "53ec153757699d3998f74891d8ac8ef13b3da2aa",
+        "sha512": "94877c4253224855753650e198df5cec908e4d07ae8f678982fa0a51a421d8f5659c2d505320a6af079da890bddca4f17d519484411bba877ca67fe545ec58b8"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/nmDcB62a/versions/LXlsO4Vo/modernfix-fabric-5.7.2%2Bmc1.19.4.jar"
+      ],
+      "fileSize": 513020
+    },
+    {
+      "path": "mods/phosphor-fabric-mc1.19.x-0.8.1.jar",
+      "hashes": {
+        "sha512": "13a0707b7a92726aa3154bc40978f36bb340d643c1d60e9fa2cbf8f7b0c7d3ea03c2a079f46a487df05e944eec9f5779afae9e99be7f70373e8a31d59948d487",
+        "sha1": "2dd6f771ba5878d81892b9487f35340e94c87a1c"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/hEOCdOgW/versions/mc1.19.x-0.8.1/phosphor-fabric-mc1.19.x-0.8.1.jar"
+      ],
+      "fileSize": 88018
+    },
+    {
+      "path": "mods/lithium-fabric-mc1.19.4-0.11.1.jar",
+      "hashes": {
+        "sha1": "69aa137957af4f0f701f6a7663c6d8646f84a1cc",
+        "sha512": "f2bd271e30e5ed9f097d592db5e859208a1c6abe727dc51f83879b837c843b4f6453e99f1ca8d5225f896233ab8f7dbbb3300f10396d2a1cd2957937acfd1aa7"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/14hWYkog/lithium-fabric-mc1.19.4-0.11.1.jar"
+      ],
+      "fileSize": 639391
+    },
+    {
+      "path": "mods/sodium-fabric-mc1.19.4-0.4.10+build.24.jar",
+      "hashes": {
+        "sha512": "61562626870aa4067657d2687d1fce80fb7d62af32fd68a22708e24ee5b84b39d16b26ccf4db8f53f2da42ba1916d6a5e11efc476cb5c2a8644207659fd5dfef",
+        "sha1": "b060680929d7a6d130fb980a9f9907461df05fa1"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/AANobbMI/versions/b4hTi3mo/sodium-fabric-mc1.19.4-0.4.10%2Bbuild.24.jar"
+      ],
+      "fileSize": 711302
     },
     {
       "path": "mods/entityculling-fabric-1.10.1-mc1.19.4.jar",
@@ -126,74 +201,14 @@
       "fileSize": 1575871
     },
     {
-      "path": "mods/c2me-fabric-mc1.19.4-0.2.0+alpha.10.66.jar",
-      "hashes": {
-        "sha1": "5c681eb7358d91faf52c7b57d590c4fa274a6847",
-        "sha512": "1cbb1fe9b3538d953e341b499c67001f9fb142bf24853a6133dbc091aa8757d47d9949a1bc04106676cfb0b3ac280409fe017c1e3d4194bf35bb606eaea6c79d"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/VSNURh3q/versions/uZ1nQtIu/c2me-fabric-mc1.19.4-0.2.0%2Balpha.10.66.jar"
-      ],
-      "fileSize": 1298898
-    },
-    {
-      "path": "mods/lithium-fabric-mc1.19.4-0.11.1.jar",
-      "hashes": {
-        "sha512": "f2bd271e30e5ed9f097d592db5e859208a1c6abe727dc51f83879b837c843b4f6453e99f1ca8d5225f896233ab8f7dbbb3300f10396d2a1cd2957937acfd1aa7",
-        "sha1": "69aa137957af4f0f701f6a7663c6d8646f84a1cc"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/14hWYkog/lithium-fabric-mc1.19.4-0.11.1.jar"
-      ],
-      "fileSize": 639391
-    },
-    {
-      "path": "mods/ImmediatelyFast-Fabric-1.2.11+1.19.4.jar",
-      "hashes": {
-        "sha1": "956a23c27590dd14195128708cd6e59b057a10dc",
-        "sha512": "c7b3443406357bad283d2214f4f99ff8760a60c60c228b2e40acc33e37409be87c3e7eebd4d33f460dd2697a25188361f8869a96e5cb2d34422a6107248d2e85"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/5ZwdcRci/versions/ezKTj0NE/ImmediatelyFast-Fabric-1.2.11%2B1.19.4.jar"
-      ],
-      "fileSize": 370128
-    },
-    {
-      "path": "mods/Ixeris-4.1.8+1.20.1-fabric.jar",
-      "hashes": {
-        "sha1": "6ee6404893d8655a2327c7c2423f381c0b4f6794",
-        "sha512": "83659b0d157079836e083ea72c4397b12f8ea93aaf492640603010fb6ddfec793568755decdce0c81745564734e624b40d43a1ec4e1e680e8f903be8b18c5e12"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/p8RJPJIC/versions/K6CavRla/Ixeris-4.1.8%2B1.20.1-fabric.jar"
-      ],
-      "fileSize": 702782
-    },
-    {
       "path": "mods/BadOptimizations-2.1.4-1.19.4.jar",
       "hashes": {
         "sha1": "330c0dd1f933d4ae5911cddc04324541dd0aea07",
         "sha512": "2455f656b056a1e3365a90079a03ef16c0a0bb10571f2ad10f0870f16c55cb32c838d0ecfadc35726b28ee768522dadb80cd3a43aeb878fadcd348405741ee75"
       },
       "env": {
-        "server": "required",
-        "client": "required"
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/g96Z4WVZ/versions/xhGlhCut/BadOptimizations-2.1.4-1.19.4.jar"
@@ -201,38 +216,38 @@
       "fileSize": 422943
     },
     {
-      "path": "mods/enhancedblockentities-0.9+1.19.4.jar",
+      "path": "mods/indium-1.0.19+mc1.19.4.jar",
       "hashes": {
-        "sha512": "a60cbef0fc67789fafefafaf799107e17b96a2d1cf67f3b8396f8960a64308c9a9d33c822a0d62f6873bf2215c2026c46b78fa2d240c0055148230f13903636d",
-        "sha1": "97ffe54d7f5294fe6c8b529f51ef4b208b3ab1a7"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/OVuFYfre/versions/Xdo5ZiRc/enhancedblockentities-0.9%2B1.19.4.jar"
-      ],
-      "fileSize": 492518
-    },
-    {
-      "path": "mods/moreculling-1.19.4-0.17.0.jar",
-      "hashes": {
-        "sha512": "bf01675be88b4770f6fa6197644978912e9d3fd547c8eeeb709102088a15b0570043f5b05c93f7d600a08ff80dad1f00b3fd52f2fb1243f9268b837e6329be52",
-        "sha1": "91d4fdb4786d2dfe56a84dff552bcadbebc88cec"
+        "sha1": "55638e279d8a19ea5df67ff86feb6350e95376e1",
+        "sha512": "676e217ba05ff49c3e8d5d801f7c157b5b988eb21a44694d5c72a279dcdfe30933f57639a66d9f49b9b10c26edb288e8aa212ba27d4bd9abe0212c52b2e9b193"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/51shyZVL/versions/A9LKf67q/moreculling-1.19.4-0.17.0.jar"
+        "https://cdn.modrinth.com/data/Orvt0mRa/versions/oYQsfz9e/indium-1.0.19%2Bmc1.19.4.jar"
       ],
-      "fileSize": 1235479
+      "fileSize": 104841
+    },
+    {
+      "path": "mods/ferritecore-5.2.0-fabric.jar",
+      "hashes": {
+        "sha512": "56a4ac2ed002260ee451fa9d33169ddcd01473bf46eee97061666b13fa386cd23e15238a72729e55f32d81cce8ae049c80caabf1947ba998258282226289be0c",
+        "sha1": "ed6fa9a9365d4e58db6703479a44cc6aed5add2f"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/uXXizFIs/versions/RbR7EG8T/ferritecore-5.2.0-fabric.jar"
+      ],
+      "fileSize": 124924
     }
   ],
   "dependencies": {
-    "fabric-loader": "0.19.0",
-    "minecraft": "1.19.4"
+    "minecraft": "1.19.4",
+    "fabric-loader": "0.19.2"
   }
 }

--- a/export/Fabric/1.20.1/modrinth.index.json
+++ b/export/Fabric/1.20.1/modrinth.index.json
@@ -1,75 +1,90 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "1.1.17",
+  "versionId": "1.2.0",
   "name": "Photon",
   "summary": "",
   "files": [
     {
-      "path": "mods/indium-1.0.36+mc1.20.1.jar",
+      "path": "mods/Ixeris-4.1.10+1.20.1-fabric.jar",
       "hashes": {
-        "sha512": "7c5a1851f1fc08ae69318e151d07151fabba6cda2a24616c9251e1a4e5b969453e88b97d60f926271d60e3511bfc6fa05a64a108466efb7f29bec4519547e0c9",
-        "sha1": "d824614e7a173d273167969f427702f51846aca7"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/Orvt0mRa/versions/nQHYSjxO/indium-1.0.36%2Bmc1.20.1.jar"
-      ],
-      "fileSize": 105382
-    },
-    {
-      "path": "mods/moreculling-1.20.1-0.24.5.jar",
-      "hashes": {
-        "sha1": "5110436d5f7867033744d2c065c44986730d79aa",
-        "sha512": "1d4a2009f55c45f5215ec9858525a8d97180c713a669afef4dd76c06e8ec134049c7cb7d4799ddd4938c2a4b1b76c8c734f7759dad42fe588d2dbc546598b0eb"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/51shyZVL/versions/3wkuUDPy/moreculling-1.20.1-0.24.5.jar"
-      ],
-      "fileSize": 274506
-    },
-    {
-      "path": "mods/Ixeris-4.1.8+1.20.1-fabric.jar",
-      "hashes": {
-        "sha512": "83659b0d157079836e083ea72c4397b12f8ea93aaf492640603010fb6ddfec793568755decdce0c81745564734e624b40d43a1ec4e1e680e8f903be8b18c5e12",
-        "sha1": "6ee6404893d8655a2327c7c2423f381c0b4f6794"
+        "sha512": "1d0f35e45d3d10d1d6d5a1df18ade64be36c6aa7dfc3626175dec6c78e54129e8fc31f7b7c02ebcafeafba683835ab2bca4d7908f74b00060c1eb660d7c0d8e4",
+        "sha1": "e477095f3c09758623a729fd1ca439cac180016c"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/p8RJPJIC/versions/K6CavRla/Ixeris-4.1.8%2B1.20.1-fabric.jar"
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/oBuFEwH4/Ixeris-4.1.10%2B1.20.1-fabric.jar"
       ],
-      "fileSize": 702782
+      "fileSize": 704470
     },
     {
-      "path": "mods/lithium-fabric-mc1.20.1-0.11.4.jar",
+      "path": "mods/ferritecore-6.0.1-fabric.jar",
       "hashes": {
-        "sha1": "048227ed60a3005cf9fa55880dfe0cf20b0ba680",
-        "sha512": "31938b7e849609892ffa1710e41f2e163d11876f824452540658c4b53cd13c666dbdad8d200989461932bd9952814c5943e64252530c72bdd5d8641775151500"
+        "sha1": "8fa3b84fc5860dbc30fdf8cced02af68dffcf3fa",
+        "sha512": "9b7dc686bfa7937815d88c7bbc6908857cd6646b05e7a96ddbdcada328a385bd4ba056532cd1d7df9d2d7f4265fd48bd49ff683f217f6d4e817177b87f6bc457"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/iEcXOkz4/lithium-fabric-mc1.20.1-0.11.4.jar"
+        "https://cdn.modrinth.com/data/uXXizFIs/versions/unerR5MN/ferritecore-6.0.1-fabric.jar"
       ],
-      "fileSize": 691483
+      "fileSize": 125197
+    },
+    {
+      "path": "mods/BadOptimizations-2.4.1-1.20.1.jar",
+      "hashes": {
+        "sha512": "5e02d9c5a5bc3dccfccbfac4809cda4eb755c015060063b696e92568e0be3d8354a01f6ac5dae99bd27111b7e20bb680512287119459ad069dcf3e7d17cace0f",
+        "sha1": "304007dcb0fb15ed1a1bc3771736470dafc5be0f"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/DIugITgU/BadOptimizations-2.4.1-1.20.1.jar"
+      ],
+      "fileSize": 460234
+    },
+    {
+      "path": "mods/zfastnoise-1.0.11+1.20.jar",
+      "hashes": {
+        "sha512": "c4e229524e309b67bdf6916c6770a2e63a20986b973874e6dd26ecb7e7f1ee4016e2283fd277cf49b597244510b6cea249c882cf6d518105ebfa566e9733b32b",
+        "sha1": "0c70551779487d7ae4e535b640f4da9c711e7612"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/OnlVIpq5/versions/dKwaus8G/zfastnoise-1.0.11%2B1.20.jar"
+      ],
+      "fileSize": 34590
+    },
+    {
+      "path": "mods/cloth-config-11.1.136-fabric.jar",
+      "hashes": {
+        "sha1": "d5fe84a0cc9ed5c7290a76ba570e1f8716afecab",
+        "sha512": "2da85c071c854223cc30c8e46794391b77e53f28ecdbbde59dc83b3dbbdfc74be9e68da9ed464e7f98b4361033899ba4f681ebff1f35edc2c60e599a59796f1c"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/9s6osm5g/versions/2xQdCMyG/cloth-config-11.1.136-fabric.jar"
+      ],
+      "fileSize": 1172214
     },
     {
       "path": "mods/c2me-fabric-mc1.20.1-0.2.0+alpha.11.16.jar",
       "hashes": {
-        "sha1": "94d96b5fffd9e98bd8448dcdd9e27f60511b1d29",
-        "sha512": "359c715fd6a0464192d36b4d9dbb7927776eaae498f0cab939b49740fc724bda83aaf4f069f395dc5975d1e82762ee3b602111d9375eb27ab6f5360c4b17f2ff"
+        "sha512": "359c715fd6a0464192d36b4d9dbb7927776eaae498f0cab939b49740fc724bda83aaf4f069f395dc5975d1e82762ee3b602111d9375eb27ab6f5360c4b17f2ff",
+        "sha1": "94d96b5fffd9e98bd8448dcdd9e27f60511b1d29"
       },
       "env": {
         "server": "required",
@@ -81,19 +96,49 @@
       "fileSize": 1426500
     },
     {
-      "path": "mods/enhancedblockentities-0.9+1.20.jar",
+      "path": "mods/sodium-fabric-0.5.13+mc1.20.1.jar",
       "hashes": {
-        "sha1": "61cfe50f69f8ef9e3640c0269ef158870f5b0410",
-        "sha512": "7e8b402fd25efd396bc7f0f25a663808ae9890accc227850c454dfcdc975657f22afceb15878e781485622434a6f6d60aff2a60264aa4425edd52ebe052a0de5"
+        "sha512": "81c64f9c2d3402dfa43ee54d8f5a054f5243bfb08984e3addcab9fe885073c79c43c1c8c41e8f30b625d26a656f82a8e5f370bbbbf222ff1c08f4b324edb7ea4",
+        "sha1": "bcdbf37d9494e405cba210d7a80ed58e756297b5"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/OVuFYfre/versions/i3v1Skck/enhancedblockentities-0.9%2B1.20.jar"
+        "https://cdn.modrinth.com/data/AANobbMI/versions/OihdIimA/sodium-fabric-0.5.13%2Bmc1.20.1.jar"
       ],
-      "fileSize": 490690
+      "fileSize": 971552
+    },
+    {
+      "path": "mods/modernfix-fabric-5.25.2+mc1.20.1.jar",
+      "hashes": {
+        "sha512": "878e39d182767ffd08ad6a3539fae780739129db133abe02b9b73dc3df6e1ac9ddbe509620356b0aae5e7bfbed535d0e18741703334317a16fefef820269da2d",
+        "sha1": "be03b9eb570c1e9df7593e68623f0fecbd039460"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/nmDcB62a/versions/rPmgLeZC/modernfix-fabric-5.25.2%2Bmc1.20.1.jar"
+      ],
+      "fileSize": 545175
+    },
+    {
+      "path": "mods/fabric-api-0.92.8+1.20.1.jar",
+      "hashes": {
+        "sha512": "c1cb983e66cb09e74d318c5e9093296be56968be36626eaa603a08826e2bf0ebde7b81ec3da81580c5e6ceae22fc29b59efe2f4d5fd9933c1352f89a878c24a4",
+        "sha1": "a563c74897cb0391cb754c7b16971f747d270ff1"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/P7dR8mSH/versions/aLxYjsiv/fabric-api-0.92.8%2B1.20.1.jar"
+      ],
+      "fileSize": 2110694
     },
     {
       "path": "mods/ImmediatelyFast-Fabric-1.5.4+1.20.4.jar",
@@ -111,59 +156,14 @@
       "fileSize": 354883
     },
     {
-      "path": "mods/modernfix-fabric-5.25.2+mc1.20.1.jar",
-      "hashes": {
-        "sha1": "be03b9eb570c1e9df7593e68623f0fecbd039460",
-        "sha512": "878e39d182767ffd08ad6a3539fae780739129db133abe02b9b73dc3df6e1ac9ddbe509620356b0aae5e7bfbed535d0e18741703334317a16fefef820269da2d"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/nmDcB62a/versions/rPmgLeZC/modernfix-fabric-5.25.2%2Bmc1.20.1.jar"
-      ],
-      "fileSize": 545175
-    },
-    {
-      "path": "mods/noisium-fabric-2.3.0+mc1.20-1.20.1.jar",
-      "hashes": {
-        "sha512": "f0abcdac514bd2b4eb6af3529eeb9980a6fef534d31244879acb291a9943151aeb34f372bf98ae01f6191870bf95e1c0bc36d522433353a1090b96e7ac03c417",
-        "sha1": "be85535cf1efe82bd8c41bcf851becaad498a598"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/KuNKN7d2/versions/erSJnRcq/noisium-fabric-2.3.0%2Bmc1.20-1.20.1.jar"
-      ],
-      "fileSize": 214902
-    },
-    {
-      "path": "mods/sodium-fabric-0.5.13+mc1.20.1.jar",
-      "hashes": {
-        "sha512": "81c64f9c2d3402dfa43ee54d8f5a054f5243bfb08984e3addcab9fe885073c79c43c1c8c41e8f30b625d26a656f82a8e5f370bbbbf222ff1c08f4b324edb7ea4",
-        "sha1": "bcdbf37d9494e405cba210d7a80ed58e756297b5"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/AANobbMI/versions/OihdIimA/sodium-fabric-0.5.13%2Bmc1.20.1.jar"
-      ],
-      "fileSize": 971552
-    },
-    {
       "path": "mods/entityculling-fabric-1.10.1-mc1.20.1.jar",
       "hashes": {
-        "sha512": "4e33a93238ccc19aa1b567de0784a6d6d885e0756731e9a4ecf7638cbc1571770d0a02edde7ae180dae38b7a44f5d67983d51aa7696d84972ceca024340abb25",
-        "sha1": "5277fece9230a4d1eab96266914bc644a8e1b1bb"
+        "sha1": "5277fece9230a4d1eab96266914bc644a8e1b1bb",
+        "sha512": "4e33a93238ccc19aa1b567de0784a6d6d885e0756731e9a4ecf7638cbc1571770d0a02edde7ae180dae38b7a44f5d67983d51aa7696d84972ceca024340abb25"
       },
       "env": {
-        "server": "required",
-        "client": "required"
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/NNAgCjsB/versions/R9LWWEsy/entityculling-fabric-1.10.1-mc1.20.1.jar"
@@ -171,68 +171,68 @@
       "fileSize": 1575495
     },
     {
-      "path": "mods/ferritecore-6.0.1-fabric.jar",
+      "path": "mods/enhancedblockentities-0.9+1.20.jar",
       "hashes": {
-        "sha512": "9b7dc686bfa7937815d88c7bbc6908857cd6646b05e7a96ddbdcada328a385bd4ba056532cd1d7df9d2d7f4265fd48bd49ff683f217f6d4e817177b87f6bc457",
-        "sha1": "8fa3b84fc5860dbc30fdf8cced02af68dffcf3fa"
+        "sha1": "61cfe50f69f8ef9e3640c0269ef158870f5b0410",
+        "sha512": "7e8b402fd25efd396bc7f0f25a663808ae9890accc227850c454dfcdc975657f22afceb15878e781485622434a6f6d60aff2a60264aa4425edd52ebe052a0de5"
       },
       "env": {
-        "client": "required",
-        "server": "required"
+        "server": "required",
+        "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/uXXizFIs/versions/unerR5MN/ferritecore-6.0.1-fabric.jar"
+        "https://cdn.modrinth.com/data/OVuFYfre/versions/i3v1Skck/enhancedblockentities-0.9%2B1.20.jar"
       ],
-      "fileSize": 125197
+      "fileSize": 490690
     },
     {
-      "path": "mods/fabric-api-0.92.7+1.20.1.jar",
+      "path": "mods/lithium-fabric-mc1.20.1-0.11.4.jar",
       "hashes": {
-        "sha512": "cba1eacbe1f249307025a780ed3b76981b84fb05e02023942425d9a720512c099137919a2ca317fdfb8d68850cd94d81ceefac7a15a6a1a1efcaccfd16feaaad",
-        "sha1": "85117a1e8984a45c972b85571c8e075cee45039a"
+        "sha512": "31938b7e849609892ffa1710e41f2e163d11876f824452540658c4b53cd13c666dbdad8d200989461932bd9952814c5943e64252530c72bdd5d8641775151500",
+        "sha1": "048227ed60a3005cf9fa55880dfe0cf20b0ba680"
       },
       "env": {
-        "client": "required",
-        "server": "required"
+        "server": "required",
+        "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/P7dR8mSH/versions/L6LGItxd/fabric-api-0.92.7%2B1.20.1.jar"
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/iEcXOkz4/lithium-fabric-mc1.20.1-0.11.4.jar"
       ],
-      "fileSize": 2107977
+      "fileSize": 691483
     },
     {
-      "path": "mods/cloth-config-11.1.136-fabric.jar",
+      "path": "mods/moreculling-1.20.1-0.24.5.jar",
       "hashes": {
-        "sha512": "2da85c071c854223cc30c8e46794391b77e53f28ecdbbde59dc83b3dbbdfc74be9e68da9ed464e7f98b4361033899ba4f681ebff1f35edc2c60e599a59796f1c",
-        "sha1": "d5fe84a0cc9ed5c7290a76ba570e1f8716afecab"
+        "sha512": "1d4a2009f55c45f5215ec9858525a8d97180c713a669afef4dd76c06e8ec134049c7cb7d4799ddd4938c2a4b1b76c8c734f7759dad42fe588d2dbc546598b0eb",
+        "sha1": "5110436d5f7867033744d2c065c44986730d79aa"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/9s6osm5g/versions/2xQdCMyG/cloth-config-11.1.136-fabric.jar"
+        "https://cdn.modrinth.com/data/51shyZVL/versions/3wkuUDPy/moreculling-1.20.1-0.24.5.jar"
       ],
-      "fileSize": 1172214
+      "fileSize": 274506
     },
     {
-      "path": "mods/BadOptimizations-2.4.1-1.20.1.jar",
+      "path": "mods/indium-1.0.36+mc1.20.1.jar",
       "hashes": {
-        "sha512": "5e02d9c5a5bc3dccfccbfac4809cda4eb755c015060063b696e92568e0be3d8354a01f6ac5dae99bd27111b7e20bb680512287119459ad069dcf3e7d17cace0f",
-        "sha1": "304007dcb0fb15ed1a1bc3771736470dafc5be0f"
+        "sha512": "7c5a1851f1fc08ae69318e151d07151fabba6cda2a24616c9251e1a4e5b969453e88b97d60f926271d60e3511bfc6fa05a64a108466efb7f29bec4519547e0c9",
+        "sha1": "d824614e7a173d273167969f427702f51846aca7"
       },
       "env": {
-        "client": "required",
-        "server": "required"
+        "server": "required",
+        "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/DIugITgU/BadOptimizations-2.4.1-1.20.1.jar"
+        "https://cdn.modrinth.com/data/Orvt0mRa/versions/nQHYSjxO/indium-1.0.36%2Bmc1.20.1.jar"
       ],
-      "fileSize": 460234
+      "fileSize": 105382
     }
   ],
   "dependencies": {
-    "fabric-loader": "0.19.1",
-    "minecraft": "1.20.1"
+    "minecraft": "1.20.1",
+    "fabric-loader": "0.19.2"
   }
 }

--- a/export/Fabric/1.20.4/modrinth.index.json
+++ b/export/Fabric/1.20.4/modrinth.index.json
@@ -1,99 +1,24 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "1.1.16",
+  "versionId": "1.2.0",
   "name": "Photon",
   "summary": "",
   "files": [
     {
-      "path": "mods/Ixeris-4.1.8+1.20.4-fabric.jar",
+      "path": "mods/lithium-fabric-mc1.20.4-0.12.1.jar",
       "hashes": {
-        "sha1": "7c3dcb5256e52e3029532dda151966ad12771190",
-        "sha512": "e3c89f5ff6cb4d59ed18c972e8dc2f267fed35d52dc2a17e77f464950cf12830206ab6286c1413d6ec3e69874d811dc92f360a7cd48bb466a37ca9d0f207b751"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/p8RJPJIC/versions/pQfTiOhJ/Ixeris-4.1.8%2B1.20.4-fabric.jar"
-      ],
-      "fileSize": 703014
-    },
-    {
-      "path": "mods/c2me-fabric-mc1.20.4-0.2.0+alpha.11.72.jar",
-      "hashes": {
-        "sha512": "bcc67b816ed01d67b5230d66f408223eb5c6d72f9fd500dab7c007a627d338491e0f1af4ba2929d35089ac9e22c9bc3a8eac48770c7c9aa7c78d70e453892ed1",
-        "sha1": "cb60c6a25b5a77fd57f18bb1fd978bb13601c6d5"
+        "sha512": "70bea154eaafb2e4b5cb755cdb12c55d50f9296ab4c2855399da548f72d6d24c0a9f77e3da2b2ea5f47fa91d1258df4d08c6c6f24a25da887ed71cea93502508",
+        "sha1": "4a0744beb2246d93cb475d21a5a53faa556956e0"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/VSNURh3q/versions/1AeveXNt/c2me-fabric-mc1.20.4-0.2.0%2Balpha.11.72.jar"
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/nMhjKWVE/lithium-fabric-mc1.20.4-0.12.1.jar"
       ],
-      "fileSize": 1289505
-    },
-    {
-      "path": "mods/indium-1.0.31+mc1.20.4.jar",
-      "hashes": {
-        "sha1": "fe6d0513ac332d890f1bd9bb9354a8e240b8f0e5",
-        "sha512": "27b4a73ca990742e27eee4348553c86c96c19fddcd0763892029f67ddbde42dc03c0ac21230403ae6b4ce4da315d0d49f582d3daab413b9ea84fd6d172ee7c4f"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/Orvt0mRa/versions/VlLxDisa/indium-1.0.31%2Bmc1.20.4.jar"
-      ],
-      "fileSize": 105350
-    },
-    {
-      "path": "mods/noisium-fabric-2.3.0+mc1.20.2-1.20.4.jar",
-      "hashes": {
-        "sha512": "249cf90051e808a224a22b6d45812831793368297c5873512a25a7e5f4b866c3d2a625b04f74ed8d9987b6171e7cca085ed8d7a100336f395cc037f1493e0e2b",
-        "sha1": "31be12110ac95503676adfaca2d9ac179e8b2072"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/KuNKN7d2/versions/RmNpWBtf/noisium-fabric-2.3.0%2Bmc1.20.2-1.20.4.jar"
-      ],
-      "fileSize": 214908
-    },
-    {
-      "path": "mods/cloth-config-13.0.138-fabric.jar",
-      "hashes": {
-        "sha512": "3863fb95cc57526c6876cb60600f2e4282a5fa8d997d981e984da48f34be654cd0c5fc09e7d77079a393b2d7e3e48baabb756ad84ea58881b22ea771f43baa4a",
-        "sha1": "e374f80329cea3d73e10e31839fe79d5a4fc0b30"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/9s6osm5g/versions/2deYQULk/cloth-config-13.0.138-fabric.jar"
-      ],
-      "fileSize": 1154870
-    },
-    {
-      "path": "mods/sodium-fabric-0.5.8+mc1.20.4.jar",
-      "hashes": {
-        "sha512": "bd00b956bde1205171e744a6a3780e835fb6928eb667fb2b56467818c979fb1e8c82561380a71a7dbfa1516cd4b6cf9087ca99f1ae066da6d65af2c828b8d554",
-        "sha1": "4c38d7b01660a27a98406767c613b3f28b6c9dfe"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/AANobbMI/versions/4GyXKCLd/sodium-fabric-0.5.8%2Bmc1.20.4.jar"
-      ],
-      "fileSize": 949085
+      "fileSize": 716022
     },
     {
       "path": "mods/fabric-api-0.97.3+1.20.4.jar",
@@ -102,8 +27,8 @@
         "sha1": "a21f3c7e700b9fc3a28e896979a07ec489507143"
       },
       "env": {
-        "server": "required",
-        "client": "required"
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/P7dR8mSH/versions/BPX6fK06/fabric-api-0.97.3%2B1.20.4.jar"
@@ -111,19 +36,19 @@
       "fileSize": 2187523
     },
     {
-      "path": "mods/lithium-fabric-mc1.20.4-0.12.1.jar",
+      "path": "mods/ImmediatelyFast-Fabric-1.5.4+1.20.4.jar",
       "hashes": {
-        "sha1": "4a0744beb2246d93cb475d21a5a53faa556956e0",
-        "sha512": "70bea154eaafb2e4b5cb755cdb12c55d50f9296ab4c2855399da548f72d6d24c0a9f77e3da2b2ea5f47fa91d1258df4d08c6c6f24a25da887ed71cea93502508"
+        "sha512": "9efa25c2062ce24ef78716c8244f89a5d393ec9f937b165ffaec2aa8c9be664acbf7168e5739a237520c59c573861a39e374fe94c35321400039ba85be4ff2a5",
+        "sha1": "bb9e7a507bb7a442cba451d79b5c1fde74aea07c"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/nMhjKWVE/lithium-fabric-mc1.20.4-0.12.1.jar"
+        "https://cdn.modrinth.com/data/5ZwdcRci/versions/Us8JqrP9/ImmediatelyFast-Fabric-1.5.4%2B1.20.4.jar"
       ],
-      "fileSize": 716022
+      "fileSize": 354883
     },
     {
       "path": "mods/moreculling-1.20.4-0.24.0.jar",
@@ -141,34 +66,49 @@
       "fileSize": 272851
     },
     {
-      "path": "mods/BadOptimizations-2.4.1-1.20.2-20.4.jar",
+      "path": "mods/c2me-fabric-mc1.20.4-0.2.0+alpha.11.72.jar",
       "hashes": {
-        "sha1": "7e378c958ae27cfb7278ea69c8195c67a17e34aa",
-        "sha512": "0a1516a6547f1f2d5180d13cebdecd44c66aad454bd66a265de9b0555505cf7eb4cc318f0cb6b5392aba42a81b708544c20fcb2c4f8fdfc07739c8533d7e7dea"
+        "sha1": "cb60c6a25b5a77fd57f18bb1fd978bb13601c6d5",
+        "sha512": "bcc67b816ed01d67b5230d66f408223eb5c6d72f9fd500dab7c007a627d338491e0f1af4ba2929d35089ac9e22c9bc3a8eac48770c7c9aa7c78d70e453892ed1"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/2j7ZpIyw/BadOptimizations-2.4.1-1.20.2-20.4.jar"
+        "https://cdn.modrinth.com/data/VSNURh3q/versions/1AeveXNt/c2me-fabric-mc1.20.4-0.2.0%2Balpha.11.72.jar"
       ],
-      "fileSize": 306487
+      "fileSize": 1289505
     },
     {
-      "path": "mods/modernfix-fabric-5.17.0+mc1.20.4.jar",
+      "path": "mods/zfastnoise-1.0.11+1.20.jar",
       "hashes": {
-        "sha512": "8404bc285100746ac76467094b2b4feb132e046272780c4c8a6d4bd4336fad70073734438e9f37bf7e46ffa65dbf2f06ab10232b09c3911c08215dfcf71fca0e",
-        "sha1": "cf5f1f0db74b0385c2738c6fbf8347e7e68100d6"
+        "sha512": "c4e229524e309b67bdf6916c6770a2e63a20986b973874e6dd26ecb7e7f1ee4016e2283fd277cf49b597244510b6cea249c882cf6d518105ebfa566e9733b32b",
+        "sha1": "0c70551779487d7ae4e535b640f4da9c711e7612"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/nmDcB62a/versions/CV2Vtn5m/modernfix-fabric-5.17.0%2Bmc1.20.4.jar"
+        "https://cdn.modrinth.com/data/OnlVIpq5/versions/dKwaus8G/zfastnoise-1.0.11%2B1.20.jar"
       ],
-      "fileSize": 458056
+      "fileSize": 34590
+    },
+    {
+      "path": "mods/Ixeris-4.1.10+1.20.4-fabric.jar",
+      "hashes": {
+        "sha1": "b68fe3e087d0b229b75146c5449bde7fe220e2a4",
+        "sha512": "dc0c2a028112a8b99d2afa30a9e3c83a79b89016de9d99d075a47c8f7819a3a97eafe2c343e279f79872cc553aba35c9bd6b18aa05e82d0546a247dff89fea24"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/KWyYXMG2/Ixeris-4.1.10%2B1.20.4-fabric.jar"
+      ],
+      "fileSize": 704705
     },
     {
       "path": "mods/enhancedblockentities-0.10.1+1.20.4.jar",
@@ -186,36 +126,6 @@
       "fileSize": 330603
     },
     {
-      "path": "mods/ImmediatelyFast-Fabric-1.5.4+1.20.4.jar",
-      "hashes": {
-        "sha1": "bb9e7a507bb7a442cba451d79b5c1fde74aea07c",
-        "sha512": "9efa25c2062ce24ef78716c8244f89a5d393ec9f937b165ffaec2aa8c9be664acbf7168e5739a237520c59c573861a39e374fe94c35321400039ba85be4ff2a5"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/5ZwdcRci/versions/Us8JqrP9/ImmediatelyFast-Fabric-1.5.4%2B1.20.4.jar"
-      ],
-      "fileSize": 354883
-    },
-    {
-      "path": "mods/entityculling-fabric-1.10.1-mc1.20.4.jar",
-      "hashes": {
-        "sha512": "b501d61653a699bef5c317e5543c3b834cea94387e3cb8db2e30f6bb801c97dbfe2c4c45a0016f475949a7938bb06f28126cb98224a593d6b84265e66f69f3a3",
-        "sha1": "fb59f60578a7c1d7311237a7003b3c64402ad3ed"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/NNAgCjsB/versions/BMyAHFy2/entityculling-fabric-1.10.1-mc1.20.4.jar"
-      ],
-      "fileSize": 1575249
-    },
-    {
       "path": "mods/ferritecore-6.0.3-fabric.jar",
       "hashes": {
         "sha512": "709ab6362dd1dcc432edd1e6c33aafba6f2d12be701bc14911107340f8ac2466779c4e57d8a303f0350c46478f23008e6eeca78e4eadedd0bdee63d4ae72ed9a",
@@ -229,10 +139,100 @@
         "https://cdn.modrinth.com/data/uXXizFIs/versions/pguEMpy9/ferritecore-6.0.3-fabric.jar"
       ],
       "fileSize": 125100
+    },
+    {
+      "path": "mods/entityculling-fabric-1.10.1-mc1.20.4.jar",
+      "hashes": {
+        "sha1": "fb59f60578a7c1d7311237a7003b3c64402ad3ed",
+        "sha512": "b501d61653a699bef5c317e5543c3b834cea94387e3cb8db2e30f6bb801c97dbfe2c4c45a0016f475949a7938bb06f28126cb98224a593d6b84265e66f69f3a3"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/NNAgCjsB/versions/BMyAHFy2/entityculling-fabric-1.10.1-mc1.20.4.jar"
+      ],
+      "fileSize": 1575249
+    },
+    {
+      "path": "mods/sodium-fabric-0.5.8+mc1.20.4.jar",
+      "hashes": {
+        "sha512": "bd00b956bde1205171e744a6a3780e835fb6928eb667fb2b56467818c979fb1e8c82561380a71a7dbfa1516cd4b6cf9087ca99f1ae066da6d65af2c828b8d554",
+        "sha1": "4c38d7b01660a27a98406767c613b3f28b6c9dfe"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/AANobbMI/versions/4GyXKCLd/sodium-fabric-0.5.8%2Bmc1.20.4.jar"
+      ],
+      "fileSize": 949085
+    },
+    {
+      "path": "mods/BadOptimizations-2.4.1-1.20.2-20.4.jar",
+      "hashes": {
+        "sha1": "7e378c958ae27cfb7278ea69c8195c67a17e34aa",
+        "sha512": "0a1516a6547f1f2d5180d13cebdecd44c66aad454bd66a265de9b0555505cf7eb4cc318f0cb6b5392aba42a81b708544c20fcb2c4f8fdfc07739c8533d7e7dea"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/2j7ZpIyw/BadOptimizations-2.4.1-1.20.2-20.4.jar"
+      ],
+      "fileSize": 306487
+    },
+    {
+      "path": "mods/indium-1.0.31+mc1.20.4.jar",
+      "hashes": {
+        "sha1": "fe6d0513ac332d890f1bd9bb9354a8e240b8f0e5",
+        "sha512": "27b4a73ca990742e27eee4348553c86c96c19fddcd0763892029f67ddbde42dc03c0ac21230403ae6b4ce4da315d0d49f582d3daab413b9ea84fd6d172ee7c4f"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/Orvt0mRa/versions/VlLxDisa/indium-1.0.31%2Bmc1.20.4.jar"
+      ],
+      "fileSize": 105350
+    },
+    {
+      "path": "mods/modernfix-fabric-5.17.0+mc1.20.4.jar",
+      "hashes": {
+        "sha1": "cf5f1f0db74b0385c2738c6fbf8347e7e68100d6",
+        "sha512": "8404bc285100746ac76467094b2b4feb132e046272780c4c8a6d4bd4336fad70073734438e9f37bf7e46ffa65dbf2f06ab10232b09c3911c08215dfcf71fca0e"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/nmDcB62a/versions/CV2Vtn5m/modernfix-fabric-5.17.0%2Bmc1.20.4.jar"
+      ],
+      "fileSize": 458056
+    },
+    {
+      "path": "mods/cloth-config-13.0.138-fabric.jar",
+      "hashes": {
+        "sha512": "3863fb95cc57526c6876cb60600f2e4282a5fa8d997d981e984da48f34be654cd0c5fc09e7d77079a393b2d7e3e48baabb756ad84ea58881b22ea771f43baa4a",
+        "sha1": "e374f80329cea3d73e10e31839fe79d5a4fc0b30"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/9s6osm5g/versions/2deYQULk/cloth-config-13.0.138-fabric.jar"
+      ],
+      "fileSize": 1154870
     }
   ],
   "dependencies": {
-    "fabric-loader": "0.19.1",
+    "fabric-loader": "0.19.2",
     "minecraft": "1.20.4"
   }
 }

--- a/export/Fabric/1.21.1/modrinth.index.json
+++ b/export/Fabric/1.21.1/modrinth.index.json
@@ -1,75 +1,45 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "1.2.17",
+  "versionId": "1.3.0",
   "name": "Photon",
   "summary": "",
   "files": [
     {
-      "path": "mods/fabric-api-0.116.10+1.21.1.jar",
+      "path": "mods/zfastnoise-1.0.11+1.21.jar",
       "hashes": {
-        "sha512": "cc8f207ca861e91c0d42f7d57b4448c2b265bbfb20f38182fad2dd14d3f4fbbbfa5c85b562ddaad33797f67fce8080b2283cdd6fa194f4ace18969d670643454",
-        "sha1": "22b506a0770f148f46737329e8cae68aaefe3165"
+        "sha1": "34a584c0e0bfa9d94cb7cd9c16b4e70ca1b30789",
+        "sha512": "16a8c997be7f14be0aeb08465a378cdc2ed2643b9a2d1f6a25dad44995d521dd16ac3809d2be79bc018d6abe9b5c051e653a230cc4a1bd8f2ebd76371e153a6e"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/P7dR8mSH/versions/ID8pq1x1/fabric-api-0.116.10%2B1.21.1.jar"
+        "https://cdn.modrinth.com/data/OnlVIpq5/versions/qETA8Qja/zfastnoise-1.0.11%2B1.21.jar"
       ],
-      "fileSize": 2425988
+      "fileSize": 34752
     },
     {
-      "path": "mods/modernfix-fabric-5.25.1+mc1.21.1.jar",
+      "path": "mods/ScalableLux-0.1.0.1+fabric.d0d58ab-all.jar",
       "hashes": {
-        "sha1": "4ab39e9c736e7204146792c545ec5b29fc0a3872",
-        "sha512": "dc67d6e023e1fcdeaf7837917c477cba212c611dfc2463c6ea021319c644087c79b477e0ea8194e113ddd7332fd5c6d82baa47c291eaac7f4a86252507b4e19f"
+        "sha1": "2ce889d9b1b210eef005ea03c3bbb39289c26e3f",
+        "sha512": "bbfe02184c3bf3b0da28175574a5a236ce7c9acc00069addd69770857f2ac572924893f3eb033bbbc965afa9779c7a7f8fc54168f9e90481a40de92f6ee3645f"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/nmDcB62a/versions/NnNX8LBn/modernfix-fabric-5.25.1%2Bmc1.21.1.jar"
+        "https://cdn.modrinth.com/data/Ps1zyz6x/versions/Yx1tgJMI/ScalableLux-0.1.0.1%2Bfabric.d0d58ab-all.jar"
       ],
-      "fileSize": 471258
-    },
-    {
-      "path": "mods/sodium-fabric-0.6.13+mc1.21.1.jar",
-      "hashes": {
-        "sha512": "13032e064c554fc8671573dadb07bc70e6ea2f68706c65c086c4feb1d2f664346a3414cbf9d1367b42b8d063a35e40f2f967ef9af31642e1f0093b852161fe91",
-        "sha1": "928a2598178c3a58b0638bab842f467d2e49251a"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/AANobbMI/versions/u1OEbNKx/sodium-fabric-0.6.13%2Bmc1.21.1.jar"
-      ],
-      "fileSize": 1297761
-    },
-    {
-      "path": "mods/enhancedblockentities-0.10.2+1.21.jar",
-      "hashes": {
-        "sha1": "d81359d77fc7c5437f3e83e519dc2f869300f0cd",
-        "sha512": "60e01db603fcf1392c0cd5c3ce742e568f7d445d83fe60828b21f546e7d29fb6947231f22d28e29b07f4bdcb767b6dc2a2398b4decea665ecba1166690a44d49"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/OVuFYfre/versions/HBZAPs3u/enhancedblockentities-0.10.2%2B1.21.jar"
-      ],
-      "fileSize": 201157
+      "fileSize": 177266
     },
     {
       "path": "mods/entityculling-fabric-1.10.1-mc1.21.1.jar",
       "hashes": {
-        "sha1": "6f7234ec1d50f563def59ab05ab44f62c119016b",
-        "sha512": "57c2db4458d64f47f28e0b753745ff0c62441372432f55454f4a626c3425b264663e0884edbb52e1f6b2545411425056707bd77cfeeac370b9a984f28c38c8c4"
+        "sha512": "57c2db4458d64f47f28e0b753745ff0c62441372432f55454f4a626c3425b264663e0884edbb52e1f6b2545411425056707bd77cfeeac370b9a984f28c38c8c4",
+        "sha1": "6f7234ec1d50f563def59ab05ab44f62c119016b"
       },
       "env": {
         "client": "required",
@@ -83,32 +53,17 @@
     {
       "path": "mods/c2me-fabric-mc1.21.1-0.3.0+alpha.0.362.jar",
       "hashes": {
-        "sha512": "8653a751eb2ad1ad70da38017ccad0ee2bda5448ffe405d28049f09a61936765303f63ba4fcff798f32bb1e6b4645e892c275515b69c98c1730e24caab0ba7e0",
-        "sha1": "9beac89c94f36a342cb07cd9fcb42608bdd07771"
+        "sha1": "9beac89c94f36a342cb07cd9fcb42608bdd07771",
+        "sha512": "8653a751eb2ad1ad70da38017ccad0ee2bda5448ffe405d28049f09a61936765303f63ba4fcff798f32bb1e6b4645e892c275515b69c98c1730e24caab0ba7e0"
       },
       "env": {
-        "server": "required",
-        "client": "required"
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/VSNURh3q/versions/DSqOVCaF/c2me-fabric-mc1.21.1-0.3.0%2Balpha.0.362.jar"
       ],
       "fileSize": 4701117
-    },
-    {
-      "path": "mods/cloth-config-15.0.140-fabric.jar",
-      "hashes": {
-        "sha1": "5d82342a2df53fd6df712bfdd583a811572918a4",
-        "sha512": "1b3f5db4fc1d481704053db9837d530919374bf7518d7cede607360f0348c04fc6347a3a72ccfef355559e1f4aef0b650cd58e5ee79c73b12ff0fc2746797a00"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/9s6osm5g/versions/HpMb5wGb/cloth-config-15.0.140-fabric.jar"
-      ],
-      "fileSize": 1157166
     },
     {
       "path": "mods/ImmediatelyFast-Fabric-1.6.10+1.21.1.jar",
@@ -117,8 +72,8 @@
         "sha512": "7117aa1b27dd1d463707d4089aa52cc09619f32744bc33363b3515b705d9ce5039fd69190092d119552b73db30ad365dffc29f84f0af505d580cc5593d88e075"
       },
       "env": {
-        "server": "required",
-        "client": "required"
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/5ZwdcRci/versions/yHztKxR5/ImmediatelyFast-Fabric-1.6.10%2B1.21.1.jar"
@@ -126,19 +81,19 @@
       "fileSize": 342770
     },
     {
-      "path": "mods/noisium-fabric-2.3.0+mc1.21-1.21.1.jar",
+      "path": "mods/sodium-fabric-0.6.13+mc1.21.1.jar",
       "hashes": {
-        "sha512": "606ba78cf7f30d99e417c96aa042f600c1b626ed9c783919496d139de650013f1434fcf93545782e3889660322837ce6e85530d9e1a5cc20f9ad161357ede43e",
-        "sha1": "642a672cfc60ff1e1262a39d7e160b1381c5120c"
+        "sha512": "13032e064c554fc8671573dadb07bc70e6ea2f68706c65c086c4feb1d2f664346a3414cbf9d1367b42b8d063a35e40f2f967ef9af31642e1f0093b852161fe91",
+        "sha1": "928a2598178c3a58b0638bab842f467d2e49251a"
       },
       "env": {
-        "server": "required",
-        "client": "required"
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/KuNKN7d2/versions/4sGQgiu2/noisium-fabric-2.3.0%2Bmc1.21-1.21.1.jar"
+        "https://cdn.modrinth.com/data/AANobbMI/versions/u1OEbNKx/sodium-fabric-0.6.13%2Bmc1.21.1.jar"
       ],
-      "fileSize": 216183
+      "fileSize": 1297761
     },
     {
       "path": "mods/moreculling-fabric-1.21.1-1.0.7.jar",
@@ -156,44 +111,44 @@
       "fileSize": 346926
     },
     {
-      "path": "mods/lithium-fabric-0.15.3+mc1.21.1.jar",
+      "path": "mods/cloth-config-15.0.140-fabric.jar",
       "hashes": {
-        "sha1": "c4a1c2b6de9915ac77ae46a005509d4acf09535d",
-        "sha512": "8c576d519121b0c2521101d2209eccd85d560b097fcb847aa54c51cd0d3f3947676f01c8d99913f514487c8e0972a1cf5f3da0c9ef0ec9bacdf2baeb4eb7d1a7"
+        "sha512": "1b3f5db4fc1d481704053db9837d530919374bf7518d7cede607360f0348c04fc6347a3a72ccfef355559e1f4aef0b650cd58e5ee79c73b12ff0fc2746797a00",
+        "sha1": "5d82342a2df53fd6df712bfdd583a811572918a4"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/XQJtuOTA/lithium-fabric-0.15.3%2Bmc1.21.1.jar"
+        "https://cdn.modrinth.com/data/9s6osm5g/versions/HpMb5wGb/cloth-config-15.0.140-fabric.jar"
       ],
-      "fileSize": 797398
+      "fileSize": 1157166
     },
     {
-      "path": "mods/Ixeris-4.1.8+1.21.1-fabric.jar",
+      "path": "mods/Ixeris-4.1.10+1.21.1-fabric.jar",
       "hashes": {
-        "sha1": "a91c59cf0497b1a026bfee4912ab40f29133f4b2",
-        "sha512": "ad5735114659b95abdf18607929e27e6b1ccc6cd25cabc7686817ff6711164b0991c20eadbf21b332306c64106cc8b995323fbeab167f9a4271d7ca48264aa7e"
+        "sha1": "09c2b90bda6b4581a5c6fcdc9df562a8dee26418",
+        "sha512": "37671b9ab94a98d666552506773ed5850288b52e1c76da8978b0b3b4d5485df85817fcecd9abab3c0d833b4f13d6915797a309101203ac512e22aa240f4f5951"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/p8RJPJIC/versions/89N9zJWk/Ixeris-4.1.8%2B1.21.1-fabric.jar"
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/NBU1saZE/Ixeris-4.1.10%2B1.21.1-fabric.jar"
       ],
-      "fileSize": 702972
+      "fileSize": 704662
     },
     {
       "path": "mods/ferritecore-7.0.3-fabric.jar",
       "hashes": {
-        "sha512": "3ad31620fac4ff44327dc7dedbe162b2d978f3f246dc16255a6e400ce9592a0d326fe36a626f3c1bf30a11f813093cbb4dcc107af039cff724d0cdf648541fdf",
-        "sha1": "a8a6a34fcda177da2828cedef44e0e538cf78aad"
+        "sha1": "a8a6a34fcda177da2828cedef44e0e538cf78aad",
+        "sha512": "3ad31620fac4ff44327dc7dedbe162b2d978f3f246dc16255a6e400ce9592a0d326fe36a626f3c1bf30a11f813093cbb4dcc107af039cff724d0cdf648541fdf"
       },
       "env": {
-        "client": "required",
-        "server": "required"
+        "server": "required",
+        "client": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/uXXizFIs/versions/sOzRw3CG/ferritecore-7.0.3-fabric.jar"
@@ -201,19 +156,64 @@
       "fileSize": 123450
     },
     {
-      "path": "mods/ScalableLux-0.1.0.1+fabric.d0d58ab-all.jar",
+      "path": "mods/modernfix-fabric-5.25.1+mc1.21.1.jar",
       "hashes": {
-        "sha512": "bbfe02184c3bf3b0da28175574a5a236ce7c9acc00069addd69770857f2ac572924893f3eb033bbbc965afa9779c7a7f8fc54168f9e90481a40de92f6ee3645f",
-        "sha1": "2ce889d9b1b210eef005ea03c3bbb39289c26e3f"
+        "sha1": "4ab39e9c736e7204146792c545ec5b29fc0a3872",
+        "sha512": "dc67d6e023e1fcdeaf7837917c477cba212c611dfc2463c6ea021319c644087c79b477e0ea8194e113ddd7332fd5c6d82baa47c291eaac7f4a86252507b4e19f"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/nmDcB62a/versions/NnNX8LBn/modernfix-fabric-5.25.1%2Bmc1.21.1.jar"
+      ],
+      "fileSize": 471258
+    },
+    {
+      "path": "mods/enhancedblockentities-0.10.2+1.21.jar",
+      "hashes": {
+        "sha1": "d81359d77fc7c5437f3e83e519dc2f869300f0cd",
+        "sha512": "60e01db603fcf1392c0cd5c3ce742e568f7d445d83fe60828b21f546e7d29fb6947231f22d28e29b07f4bdcb767b6dc2a2398b4decea665ecba1166690a44d49"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/OVuFYfre/versions/HBZAPs3u/enhancedblockentities-0.10.2%2B1.21.jar"
+      ],
+      "fileSize": 201157
+    },
+    {
+      "path": "mods/lithium-fabric-0.15.3+mc1.21.1.jar",
+      "hashes": {
+        "sha512": "8c576d519121b0c2521101d2209eccd85d560b097fcb847aa54c51cd0d3f3947676f01c8d99913f514487c8e0972a1cf5f3da0c9ef0ec9bacdf2baeb4eb7d1a7",
+        "sha1": "c4a1c2b6de9915ac77ae46a005509d4acf09535d"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/XQJtuOTA/lithium-fabric-0.15.3%2Bmc1.21.1.jar"
+      ],
+      "fileSize": 797398
+    },
+    {
+      "path": "mods/fabric-api-0.116.11+1.21.1.jar",
+      "hashes": {
+        "sha512": "756b8c086f4c911d012f2eb70ca792aef0439503b31bc52026b82830870a94d472de30d61a6a0a9988c02b8462d9c47aa6baa6cd84da1eaf00edb77249b3c413",
+        "sha1": "65f4e8b9dcbad6697b2fb32fa0bb937ec5efcd84"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/Ps1zyz6x/versions/Yx1tgJMI/ScalableLux-0.1.0.1%2Bfabric.d0d58ab-all.jar"
+        "https://cdn.modrinth.com/data/P7dR8mSH/versions/IpaMcBLh/fabric-api-0.116.11%2B1.21.1.jar"
       ],
-      "fileSize": 177266
+      "fileSize": 2426356
     },
     {
       "path": "mods/BadOptimizations-2.4.1-1.21.1.jar",
@@ -222,8 +222,8 @@
         "sha512": "2b66428bd98bd5ec0e09f2ec6af801cefb7b9b99cc4f0993daeaffe8d0ccc5ee0c2a73e9f38d4f92540ead0181704d2c9e946837ec05cf710fc3b20fce3b0cac"
       },
       "env": {
-        "server": "required",
-        "client": "required"
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/g96Z4WVZ/versions/S2qthD5S/BadOptimizations-2.4.1-1.21.1.jar"

--- a/export/Fabric/1.21.11/modrinth.index.json
+++ b/export/Fabric/1.21.11/modrinth.index.json
@@ -1,154 +1,49 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "1.0.9",
+  "versionId": "1.1.0",
   "name": "Photon",
   "summary": "",
   "files": [
     {
-      "path": "mods/lithium-fabric-0.21.4+mc1.21.11.jar",
+      "path": "mods/zfastnoise-1.0.29+1.21.11.jar",
       "hashes": {
-        "sha512": "f14a5c3d2fad786347ca25083f902139694f618b7c103947f2fd067a7c5ee88a63e1ef8926f7d693ea79ed7d00f57317bae77ef9c2d630bf5ed01ac97a752b94",
-        "sha1": "203bdcb26e97b3217b045e1182651a7d7b6462ec"
+        "sha512": "18151ac6e803f7ff0ddcfc8680238ee052b0ae3fddafa8d2773a37de9965a41b8a0264591523f76361290ed40a44be6a448fb4d84e8e8a386a52f3292b9bc013",
+        "sha1": "8c0b5ad24140bd91cdb8e4223d27620e641764c0"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/Ow7wA0kG/lithium-fabric-0.21.4%2Bmc1.21.11.jar"
+        "https://cdn.modrinth.com/data/OnlVIpq5/versions/iokxBbTT/zfastnoise-1.0.29%2B1.21.11.jar"
       ],
-      "fileSize": 900462
+      "fileSize": 455559
     },
     {
-      "path": "mods/ImmediatelyFast-Fabric-1.14.2+1.21.11.jar",
+      "path": "mods/Ixeris-4.1.10+1.21.11-fabric.jar",
       "hashes": {
-        "sha1": "4f17c6b7388f0afc5d24075dc2a294963f78c712",
-        "sha512": "dedff930a4e317994579020eaeef9f56d81d5215d871372d206fc974842d87e80e4be15d8571a4eaa4320c2412701ea093ba4494a47e8988e3d448ec8adcba37"
+        "sha1": "42c130c7b7c068dc3442ab2efb50e7c9930ae802",
+        "sha512": "38093de218550151db1ee0c9a6178d69f58db8886877c7744948b3e627455d6ebd25b173e2cf513376b0aac32329f50a8d1427a5bd513b72439ac5ae0ae98632"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/5ZwdcRci/versions/QwkfUKSj/ImmediatelyFast-Fabric-1.14.2%2B1.21.11.jar"
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/5VdrF7hS/Ixeris-4.1.10%2B1.21.11-fabric.jar"
       ],
-      "fileSize": 310445
-    },
-    {
-      "path": "mods/cloth-config-21.11.153-fabric.jar",
-      "hashes": {
-        "sha1": "4c224606a963bce223db5b27edb4959ecf40d4ee",
-        "sha512": "8f455489d4b71069e998568cf4e1450116f4360a4eb481cd89117f629c6883164886cf63ca08ac4fc929dd13d1112152755a6216d4a1498ee6406ef102093e51"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/9s6osm5g/versions/xuX40TN5/cloth-config-21.11.153-fabric.jar"
-      ],
-      "fileSize": 1148427
-    },
-    {
-      "path": "mods/BadOptimizations-2.4.1-1.21.11.jar",
-      "hashes": {
-        "sha1": "70fa28d5a7a1fdd61dd804ca6ac411750da1473f",
-        "sha512": "ff91f1866f21a13a32d379080b8efb5d4e07577591228c1d307b34d052696c9bdcbaf7706208dfbac56abc2c29482a15edcbf11f69fc0a01e459c4c20a5c2c28"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/Q3Dusz2j/BadOptimizations-2.4.1-1.21.11.jar"
-      ],
-      "fileSize": 269545
-    },
-    {
-      "path": "mods/fabric-api-0.141.3+1.21.11.jar",
-      "hashes": {
-        "sha1": "50de67eb221f0b38216da8668b09ca311327040e",
-        "sha512": "c20c017e23d6d2774690d0dd774cec84c16bfac5461da2d9345a1cd95eee495b1954333c421e3d1c66186284d24a433f6b0cced8021f62e0bfa617d2384d0471"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/P7dR8mSH/versions/i5tSkVBH/fabric-api-0.141.3%2B1.21.11.jar"
-      ],
-      "fileSize": 2412693
-    },
-    {
-      "path": "mods/modernfix-5.26.2-build.1.jar",
-      "hashes": {
-        "sha1": "959efa1690550b4e09616f808d5a5ee52c47477f",
-        "sha512": "d57be559b6d2ee802df3617a7d44586f690db27998cfc04f195ec645a754a9be9fcd7e824313671711b0e318720f39f0e96db46727a21ff17b4fa3187fbdf399"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/TjSm1wrD/versions/6q6pkhVP/modernfix-5.26.2-build.1.jar"
-      ],
-      "fileSize": 627253
-    },
-    {
-      "path": "mods/Ixeris-4.1.8+1.21.11-fabric.jar",
-      "hashes": {
-        "sha1": "a4bc219f61a33bc18b038cbebd8da0f7d7a0056c",
-        "sha512": "db9ceeccf89c2e0736133a4361c41c62a742befce55724f529faf870056eaedd89105dae3a1675ee1dc8bf633a6931e691c66ea966e2feadb5517febdf01b292"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/p8RJPJIC/versions/sVbnqVVv/Ixeris-4.1.8%2B1.21.11-fabric.jar"
-      ],
-      "fileSize": 703785
-    },
-    {
-      "path": "mods/ferritecore-8.2.0-fabric.jar",
-      "hashes": {
-        "sha1": "c2e2f5e008f5bc9f401dfad8ca94909917006b65",
-        "sha512": "3210926a82eb32efd9bcebabe2f6c053daf5c4337eebc6d5bacba96d283510afbde646e7e195751de795ec70a2ea44fef77cb54bf22c8e57bb832d6217418869"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/uXXizFIs/versions/Ii0gP3D8/ferritecore-8.2.0-fabric.jar"
-      ],
-      "fileSize": 80138
-    },
-    {
-      "path": "mods/c2me-fabric-mc1.21.11-0.3.6.0.0.jar",
-      "hashes": {
-        "sha1": "587f9a3d9e4591e8e1a1c3eda61ed2f7bfa5dc46",
-        "sha512": "c9b11100572fb71c3080ff11b011467624e8013b9942aade09a5c77eb62b3289667bad70501ddea8f35deb0a5d26884b79f76d4ed112d32342471ca7384b788a"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/VSNURh3q/versions/olrVZpJd/c2me-fabric-mc1.21.11-0.3.6.0.0.jar"
-      ],
-      "fileSize": 4687147
+      "fileSize": 705479
     },
     {
       "path": "mods/sodium-fabric-0.8.7+mc1.21.11.jar",
       "hashes": {
-        "sha1": "e8865210ba9a926fc206ab9e73f9d4988a81ff69",
-        "sha512": "d7f035d6112eaac92cf0f11e4426db631fca5a7115dd355c2126efee4255b648a0102552bbf7b22a7eae9203d08f8740435842bfddcd94e2434f51b57ee9c641"
+        "sha512": "d7f035d6112eaac92cf0f11e4426db631fca5a7115dd355c2126efee4255b648a0102552bbf7b22a7eae9203d08f8740435842bfddcd94e2434f51b57ee9c641",
+        "sha1": "e8865210ba9a926fc206ab9e73f9d4988a81ff69"
       },
       "env": {
-        "server": "required",
-        "client": "required"
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/AANobbMI/versions/UddlN6L4/sodium-fabric-0.8.7%2Bmc1.21.11.jar"
@@ -156,34 +51,34 @@
       "fileSize": 1870358
     },
     {
-      "path": "mods/ScalableLux-0.1.6+fabric.c25518a-all.jar",
+      "path": "mods/fabric-api-0.141.3+1.21.11.jar",
       "hashes": {
-        "sha512": "729515c1e75cf8d9cd704f12b3487ddb9664cf9928e7b85b12289c8fbbc7ed82d0211e1851375cbd5b385820b4fedbc3f617038fff5e30b302047b0937042ae7",
-        "sha1": "9df93ab6442fa374c17fab6b5181fe2c215d9d5b"
+        "sha512": "c20c017e23d6d2774690d0dd774cec84c16bfac5461da2d9345a1cd95eee495b1954333c421e3d1c66186284d24a433f6b0cced8021f62e0bfa617d2384d0471",
+        "sha1": "50de67eb221f0b38216da8668b09ca311327040e"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/Ps1zyz6x/versions/PV9KcrYQ/ScalableLux-0.1.6%2Bfabric.c25518a-all.jar"
+        "https://cdn.modrinth.com/data/P7dR8mSH/versions/i5tSkVBH/fabric-api-0.141.3%2B1.21.11.jar"
       ],
-      "fileSize": 182846
+      "fileSize": 2412693
     },
     {
-      "path": "mods/noisium-fabric-2.8.3+mc1.21.11.jar",
+      "path": "mods/BadOptimizations-2.4.1-1.21.11.jar",
       "hashes": {
-        "sha1": "2851c7824664bc970367f89710ffd569f49a761c",
-        "sha512": "03d4c116204ee8cb4f95b668576c9e8c099ed939c150ff0cf4ff094ae52b0c5f6214c1292c94f25ea7f614254151d1ff2db68ecaddc9f56486189d29fa3a24eb"
+        "sha512": "ff91f1866f21a13a32d379080b8efb5d4e07577591228c1d307b34d052696c9bdcbaf7706208dfbac56abc2c29482a15edcbf11f69fc0a01e459c4c20a5c2c28",
+        "sha1": "70fa28d5a7a1fdd61dd804ca6ac411750da1473f"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/hasdd01q/versions/VyMvRQKq/noisium-fabric-2.8.3%2Bmc1.21.11.jar"
+        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/Q3Dusz2j/BadOptimizations-2.4.1-1.21.11.jar"
       ],
-      "fileSize": 225560
+      "fileSize": 269545
     },
     {
       "path": "mods/moreculling-fabric-1.21.11-1.6.2.jar",
@@ -201,23 +96,128 @@
       "fileSize": 340975
     },
     {
-      "path": "mods/entityculling-fabric-1.10.1-mc1.21.11.jar",
+      "path": "mods/cloth-config-21.11.153-fabric.jar",
       "hashes": {
-        "sha512": "93fac75432afb97f286827190b3e0363775e013946e22bc62cd86b1d0e0c10c1e7dbd520ca22a9445acb1f50afca38c12d41a4f9a4d3685218287bb7cad237b8",
-        "sha1": "4e595b6162d24c3d8d65bc6417cf79daac5bde0d"
+        "sha1": "4c224606a963bce223db5b27edb4959ecf40d4ee",
+        "sha512": "8f455489d4b71069e998568cf4e1450116f4360a4eb481cd89117f629c6883164886cf63ca08ac4fc929dd13d1112152755a6216d4a1498ee6406ef102093e51"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/9s6osm5g/versions/xuX40TN5/cloth-config-21.11.153-fabric.jar"
+      ],
+      "fileSize": 1148427
+    },
+    {
+      "path": "mods/ScalableLux-0.1.6+fabric.c25518a-all.jar",
+      "hashes": {
+        "sha1": "9df93ab6442fa374c17fab6b5181fe2c215d9d5b",
+        "sha512": "729515c1e75cf8d9cd704f12b3487ddb9664cf9928e7b85b12289c8fbbc7ed82d0211e1851375cbd5b385820b4fedbc3f617038fff5e30b302047b0937042ae7"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
+        "https://cdn.modrinth.com/data/Ps1zyz6x/versions/PV9KcrYQ/ScalableLux-0.1.6%2Bfabric.c25518a-all.jar"
+      ],
+      "fileSize": 182846
+    },
+    {
+      "path": "mods/ImmediatelyFast-Fabric-1.14.2+1.21.11.jar",
+      "hashes": {
+        "sha1": "4f17c6b7388f0afc5d24075dc2a294963f78c712",
+        "sha512": "dedff930a4e317994579020eaeef9f56d81d5215d871372d206fc974842d87e80e4be15d8571a4eaa4320c2412701ea093ba4494a47e8988e3d448ec8adcba37"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/5ZwdcRci/versions/QwkfUKSj/ImmediatelyFast-Fabric-1.14.2%2B1.21.11.jar"
+      ],
+      "fileSize": 310445
+    },
+    {
+      "path": "mods/ferritecore-8.2.0-fabric.jar",
+      "hashes": {
+        "sha1": "c2e2f5e008f5bc9f401dfad8ca94909917006b65",
+        "sha512": "3210926a82eb32efd9bcebabe2f6c053daf5c4337eebc6d5bacba96d283510afbde646e7e195751de795ec70a2ea44fef77cb54bf22c8e57bb832d6217418869"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/uXXizFIs/versions/Ii0gP3D8/ferritecore-8.2.0-fabric.jar"
+      ],
+      "fileSize": 80138
+    },
+    {
+      "path": "mods/lithium-fabric-0.21.4+mc1.21.11.jar",
+      "hashes": {
+        "sha512": "f14a5c3d2fad786347ca25083f902139694f618b7c103947f2fd067a7c5ee88a63e1ef8926f7d693ea79ed7d00f57317bae77ef9c2d630bf5ed01ac97a752b94",
+        "sha1": "203bdcb26e97b3217b045e1182651a7d7b6462ec"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/Ow7wA0kG/lithium-fabric-0.21.4%2Bmc1.21.11.jar"
+      ],
+      "fileSize": 900462
+    },
+    {
+      "path": "mods/c2me-fabric-mc1.21.11-0.3.6.0.0.jar",
+      "hashes": {
+        "sha1": "587f9a3d9e4591e8e1a1c3eda61ed2f7bfa5dc46",
+        "sha512": "c9b11100572fb71c3080ff11b011467624e8013b9942aade09a5c77eb62b3289667bad70501ddea8f35deb0a5d26884b79f76d4ed112d32342471ca7384b788a"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/VSNURh3q/versions/olrVZpJd/c2me-fabric-mc1.21.11-0.3.6.0.0.jar"
+      ],
+      "fileSize": 4687147
+    },
+    {
+      "path": "mods/entityculling-fabric-1.10.1-mc1.21.11.jar",
+      "hashes": {
+        "sha1": "4e595b6162d24c3d8d65bc6417cf79daac5bde0d",
+        "sha512": "93fac75432afb97f286827190b3e0363775e013946e22bc62cd86b1d0e0c10c1e7dbd520ca22a9445acb1f50afca38c12d41a4f9a4d3685218287bb7cad237b8"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
         "https://cdn.modrinth.com/data/NNAgCjsB/versions/WORDhU8n/entityculling-fabric-1.10.1-mc1.21.11.jar"
       ],
       "fileSize": 1585638
+    },
+    {
+      "path": "mods/modernfix-5.26.2-build.1.jar",
+      "hashes": {
+        "sha512": "d57be559b6d2ee802df3617a7d44586f690db27998cfc04f195ec645a754a9be9fcd7e824313671711b0e318720f39f0e96db46727a21ff17b4fa3187fbdf399",
+        "sha1": "959efa1690550b4e09616f808d5a5ee52c47477f"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/TjSm1wrD/versions/6q6pkhVP/modernfix-5.26.2-build.1.jar"
+      ],
+      "fileSize": 627253
     }
   ],
   "dependencies": {
-    "minecraft": "1.21.11",
-    "fabric-loader": "0.19.1"
+    "fabric-loader": "0.19.2",
+    "minecraft": "1.21.11"
   }
 }

--- a/export/Fabric/26.1.2/modrinth.index.json
+++ b/export/Fabric/26.1.2/modrinth.index.json
@@ -1,120 +1,15 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "0.1.1",
+  "versionId": "0.2.0",
   "name": "Photon",
   "summary": "",
   "files": [
     {
-      "path": "mods/moreculling-fabric-26.1.1-1.7.0-beta.5.jar",
-      "hashes": {
-        "sha512": "57556eb3280637c5666e0a4e93d8b92912848ba7804014d56f73e1363b3e1f7b272f5641cd08420123b9bf68ec9c5d71c2314ba3e4c5d69e5c4e00f0e925ddd8",
-        "sha1": "7831be27edaf8581c6bba15867b2a47f4ee9b625"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/51shyZVL/versions/KJBkanxk/moreculling-fabric-26.1.1-1.7.0-beta.5.jar"
-      ],
-      "fileSize": 358073
-    },
-    {
-      "path": "mods/noisium-fabric-2.8.4+mc26.1-pre-2.jar",
-      "hashes": {
-        "sha512": "757f3e4f5271f221a715df3c27c5da5f5c9612dbfba2a298cbda9381de1b832524ae676868839a6c93cb88612181a8ed5ab5f848e0fa768ac0750c1c38a88636",
-        "sha1": "3ca0f8a504a80dcd084a5c6f801beda50d67db08"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/hasdd01q/versions/QWyo5TsS/noisium-fabric-2.8.4%2Bmc26.1-pre-2.jar"
-      ],
-      "fileSize": 70336
-    },
-    {
-      "path": "mods/fabric-api-0.146.0+26.1.2.jar",
-      "hashes": {
-        "sha1": "9476711a2863670fc038e084f295269706f706a4",
-        "sha512": "b958fb84cf9af3590f6e942b25eefb1dcda5e670215b8d7377b6906ffa937525be22e19cd7f31dd7d280bff9453d488c09bf5dd32433d91fa45f128d57d0cea4"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/P7dR8mSH/versions/Jj2SOUMp/fabric-api-0.146.0%2B26.1.2.jar"
-      ],
-      "fileSize": 2408600
-    },
-    {
-      "path": "mods/ImmediatelyFast-Fabric-1.15.2+26.1.2.jar",
-      "hashes": {
-        "sha1": "195bc6059dda0aac574906d035fae0b62a575a87",
-        "sha512": "46371d0958d705182e0945a0bd93b750a07a1f32a4f3189d85741804392137a47790d3bd0e341e7e9d5bf2783652598575ae1dc26f188aa9a71758f9d568e709"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/5ZwdcRci/versions/lRuSLf0Y/ImmediatelyFast-Fabric-1.15.2%2B26.1.2.jar"
-      ],
-      "fileSize": 304946
-    },
-    {
-      "path": "mods/c2me-fabric-mc26.1.2-0.3.7+alpha.0.65.jar",
-      "hashes": {
-        "sha512": "6666ebaa3bfa403e386776590fc845b7c306107d37ebc7b1be3b057893fbf9f933abb2314c171d7fe19c177cf8823cb47fdc32040d34a9704f5ab656dd5d93f8",
-        "sha1": "b2ad88cbe82f510d178726e6304f575892b53878"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/VSNURh3q/versions/yrNQQ1AQ/c2me-fabric-mc26.1.2-0.3.7%2Balpha.0.65.jar"
-      ],
-      "fileSize": 4728926
-    },
-    {
-      "path": "mods/cloth-config-26.1.154.jar",
-      "hashes": {
-        "sha512": "8bfb75f2cac0a9910316c6a368a228c0f8f1261ac6f03dec5fba594e1619ac04334a3df4fb29778d61d0b8290d55949371a523d722b35501bf9a2902956d3b17",
-        "sha1": "832f9047bc4af13587709c74f7c37e1c8579d1eb"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/9s6osm5g/versions/GFM8zh9J/cloth-config-26.1.154.jar"
-      ],
-      "fileSize": 1135373
-    },
-    {
-      "path": "mods/ScalableLux-0.2.0+fabric.2b63825-all.jar",
-      "hashes": {
-        "sha1": "3875a697a9bb014c06aa3a62d72e8bec3de23160",
-        "sha512": "48565a4d8a1cbd623f0044086d971f2c0cf1c40e1d0b6636a61d41512f4c1c1ddff35879d9dba24b088a670ee254e2d5842d13a30b6d76df23706fa94ea4a58b"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/Ps1zyz6x/versions/gYbHVCz8/ScalableLux-0.2.0%2Bfabric.2b63825-all.jar"
-      ],
-      "fileSize": 183504
-    },
-    {
       "path": "mods/modernfix-5.27.5-build.2.jar",
       "hashes": {
-        "sha512": "1ac2938e1cabe026ef667d6556874e1125ace2df1d0c0cd73fa6ee6224cd8850d00a2a92c90aa7ae9881c71a3dda628a18128fa7ce5fcd89247eadef6771c741",
-        "sha1": "2a52e6878e4c0237d0a2a45af47fb65342904199"
+        "sha1": "2a52e6878e4c0237d0a2a45af47fb65342904199",
+        "sha512": "1ac2938e1cabe026ef667d6556874e1125ace2df1d0c0cd73fa6ee6224cd8850d00a2a92c90aa7ae9881c71a3dda628a18128fa7ce5fcd89247eadef6771c741"
       },
       "env": {
         "server": "required",
@@ -126,49 +21,49 @@
       "fileSize": 680612
     },
     {
-      "path": "mods/lithium-fabric-0.24.1+mc26.1.2.jar",
+      "path": "mods/lithium-fabric-0.24.2+mc26.1.2.jar",
       "hashes": {
-        "sha512": "8711bc8c6f39be4c8511becb7a68e573ced56777bd691639f2fc62299b35bb4ccd2efe4a39bd9c308084b523be86a5f5c4bf921ab85f7a22bf075d8ea2359621",
-        "sha1": "987c45786c145803e9a6d20718d65242b699de6f"
+        "sha1": "a2575886c93255a73e5c583e89332b8bd56023d3",
+        "sha512": "9231ad05667d4eef0348c700bf5160929e0b723d9e145fd97c7fcef9387ac2e6d524fb15d99f47f8f838f1d235324fd750cdcb6603b63aab6085d79fbeaab31b"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/R7MxYvuW/lithium-fabric-0.24.2%2Bmc26.1.2.jar"
+      ],
+      "fileSize": 882624
+    },
+    {
+      "path": "mods/cloth-config-26.1.154.jar",
+      "hashes": {
+        "sha512": "8bfb75f2cac0a9910316c6a368a228c0f8f1261ac6f03dec5fba594e1619ac04334a3df4fb29778d61d0b8290d55949371a523d722b35501bf9a2902956d3b17",
+        "sha1": "832f9047bc4af13587709c74f7c37e1c8579d1eb"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/9s6osm5g/versions/GFM8zh9J/cloth-config-26.1.154.jar"
+      ],
+      "fileSize": 1135373
+    },
+    {
+      "path": "mods/c2me-fabric-mc26.1.2-0.3.7+alpha.0.65.jar",
+      "hashes": {
+        "sha1": "b2ad88cbe82f510d178726e6304f575892b53878",
+        "sha512": "6666ebaa3bfa403e386776590fc845b7c306107d37ebc7b1be3b057893fbf9f933abb2314c171d7fe19c177cf8823cb47fdc32040d34a9704f5ab656dd5d93f8"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/v2xoRvRP/lithium-fabric-0.24.1%2Bmc26.1.2.jar"
+        "https://cdn.modrinth.com/data/VSNURh3q/versions/yrNQQ1AQ/c2me-fabric-mc26.1.2-0.3.7%2Balpha.0.65.jar"
       ],
-      "fileSize": 883562
-    },
-    {
-      "path": "mods/sodium-fabric-0.8.9+mc26.1.1.jar",
-      "hashes": {
-        "sha512": "74f9dc8963b5258226837cc361ba6b525da734ab4fa5f05d1862bc6e9175f4fa81ca3d49443e2fb85be144d06042f0d65cbcceefc391043af857b38aa2614ae8",
-        "sha1": "48b949ec71365788dfd4e89d489f7abd504aa709"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/AANobbMI/versions/uGvVQBnw/sodium-fabric-0.8.9%2Bmc26.1.1.jar"
-      ],
-      "fileSize": 1810286
-    },
-    {
-      "path": "mods/BadOptimizations-2.4.1-26.1-fabric.jar",
-      "hashes": {
-        "sha512": "efba144dec306767da3aceb4b179e093daa60bc4c0ba6295d64c166092b8f62e4a4cc63a5bae76fb4c608f1dffa8ecd70c6884e48c804915e1b37ef042e31a99",
-        "sha1": "9636073ca8f378ea796b5d13bffac146a7f2f0f3"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/gjIvugXc/BadOptimizations-2.4.1-26.1-fabric.jar"
-      ],
-      "fileSize": 61928
+      "fileSize": 4728926
     },
     {
       "path": "mods/entityculling-fabric-1.10.1-mc26.1.jar",
@@ -186,6 +81,81 @@
       "fileSize": 1563254
     },
     {
+      "path": "mods/fabric-api-0.146.1+26.1.2.jar",
+      "hashes": {
+        "sha512": "cd8a760ecb976127036f8047c1e968f264aea9cd9deca60e6e9cb57496b1b5cca79873c59b7ab46b92f49ac22f49a2b695bb6ebe61653c8df6954e97b8836890",
+        "sha1": "d2ee4e810cc926a38758e7a0f6e1497382be557a"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/P7dR8mSH/versions/tnmuHGZA/fabric-api-0.146.1%2B26.1.2.jar"
+      ],
+      "fileSize": 2409383
+    },
+    {
+      "path": "mods/Ixeris-4.1.10+26.1.2-fabric.jar",
+      "hashes": {
+        "sha512": "e7c865b2e4766849addb0c88de345952388fc99625fcb5d24bcaaec47be8ead0a98a07984a3bcf3c7c666351588acae0d3ecabeb6ca35da2205edf3a22519df8",
+        "sha1": "05fcd02c4cfe4a2e795964495a049806cc26fddd"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/6zryDipI/Ixeris-4.1.10%2B26.1.2-fabric.jar"
+      ],
+      "fileSize": 692374
+    },
+    {
+      "path": "mods/ScalableLux-0.2.0+fabric.2b63825-all.jar",
+      "hashes": {
+        "sha512": "48565a4d8a1cbd623f0044086d971f2c0cf1c40e1d0b6636a61d41512f4c1c1ddff35879d9dba24b088a670ee254e2d5842d13a30b6d76df23706fa94ea4a58b",
+        "sha1": "3875a697a9bb014c06aa3a62d72e8bec3de23160"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/Ps1zyz6x/versions/gYbHVCz8/ScalableLux-0.2.0%2Bfabric.2b63825-all.jar"
+      ],
+      "fileSize": 183504
+    },
+    {
+      "path": "mods/sodium-fabric-0.8.9+mc26.1.1.jar",
+      "hashes": {
+        "sha512": "74f9dc8963b5258226837cc361ba6b525da734ab4fa5f05d1862bc6e9175f4fa81ca3d49443e2fb85be144d06042f0d65cbcceefc391043af857b38aa2614ae8",
+        "sha1": "48b949ec71365788dfd4e89d489f7abd504aa709"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/AANobbMI/versions/uGvVQBnw/sodium-fabric-0.8.9%2Bmc26.1.1.jar"
+      ],
+      "fileSize": 1810286
+    },
+    {
+      "path": "mods/moreculling-fabric-26.1.1-1.7.0-beta.5.jar",
+      "hashes": {
+        "sha512": "57556eb3280637c5666e0a4e93d8b92912848ba7804014d56f73e1363b3e1f7b272f5641cd08420123b9bf68ec9c5d71c2314ba3e4c5d69e5c4e00f0e925ddd8",
+        "sha1": "7831be27edaf8581c6bba15867b2a47f4ee9b625"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/51shyZVL/versions/KJBkanxk/moreculling-fabric-26.1.1-1.7.0-beta.5.jar"
+      ],
+      "fileSize": 358073
+    },
+    {
       "path": "mods/ferritecore-9.0.0-fabric.jar",
       "hashes": {
         "sha512": "d81fa97e11784c19d42f89c2f433831d007603dd7193cee45fa177e4a6a9c52b384b198586e04a0f7f63cd996fed713322578bde9a8db57e1188854ae5cbe584",
@@ -201,23 +171,53 @@
       "fileSize": 72677
     },
     {
-      "path": "mods/Ixeris-4.1.8+26.1.1-fabric.jar",
+      "path": "mods/BadOptimizations-2.4.1-26.1-fabric.jar",
       "hashes": {
-        "sha512": "04f0a37d8c9373e5466b29dce9dab1690eb3988f3d3a807511d613fe8591651d2852e72e774e09c8fc5d6893842ecca33ec5a4676f53d7ae9a20eceee58c9cc0",
-        "sha1": "78f1acad0c34f072a0a3183b7d0f86a311f9b307"
+        "sha1": "9636073ca8f378ea796b5d13bffac146a7f2f0f3",
+        "sha512": "efba144dec306767da3aceb4b179e093daa60bc4c0ba6295d64c166092b8f62e4a4cc63a5bae76fb4c608f1dffa8ecd70c6884e48c804915e1b37ef042e31a99"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/gjIvugXc/BadOptimizations-2.4.1-26.1-fabric.jar"
+      ],
+      "fileSize": 61928
+    },
+    {
+      "path": "mods/ImmediatelyFast-Fabric-1.15.2+26.1.2.jar",
+      "hashes": {
+        "sha1": "195bc6059dda0aac574906d035fae0b62a575a87",
+        "sha512": "46371d0958d705182e0945a0bd93b750a07a1f32a4f3189d85741804392137a47790d3bd0e341e7e9d5bf2783652598575ae1dc26f188aa9a71758f9d568e709"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/p8RJPJIC/versions/3zCbd4Se/Ixeris-4.1.8%2B26.1.1-fabric.jar"
+        "https://cdn.modrinth.com/data/5ZwdcRci/versions/lRuSLf0Y/ImmediatelyFast-Fabric-1.15.2%2B26.1.2.jar"
       ],
-      "fileSize": 690709
+      "fileSize": 304946
+    },
+    {
+      "path": "mods/noisium-fabric-2.8.4+mc26.1-pre-2.jar",
+      "hashes": {
+        "sha512": "757f3e4f5271f221a715df3c27c5da5f5c9612dbfba2a298cbda9381de1b832524ae676868839a6c93cb88612181a8ed5ab5f848e0fa768ac0750c1c38a88636",
+        "sha1": "3ca0f8a504a80dcd084a5c6f801beda50d67db08"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/hasdd01q/versions/QWyo5TsS/noisium-fabric-2.8.4%2Bmc26.1-pre-2.jar"
+      ],
+      "fileSize": 70336
     }
   ],
   "dependencies": {
-    "fabric-loader": "0.19.2",
-    "minecraft": "26.1.2"
+    "minecraft": "26.1.2",
+    "fabric-loader": "0.19.2"
   }
 }

--- a/export/Fabric/26.1.2/modrinth.index.json
+++ b/export/Fabric/26.1.2/modrinth.index.json
@@ -6,14 +6,74 @@
   "summary": "",
   "files": [
     {
-      "path": "mods/modernfix-5.27.5-build.2.jar",
+      "path": "mods/zfastnoise-1.0.29-ocl+26.1.2.jar",
       "hashes": {
-        "sha1": "2a52e6878e4c0237d0a2a45af47fb65342904199",
-        "sha512": "1ac2938e1cabe026ef667d6556874e1125ace2df1d0c0cd73fa6ee6224cd8850d00a2a92c90aa7ae9881c71a3dda628a18128fa7ce5fcd89247eadef6771c741"
+        "sha512": "d5c7d38189fff63b71a48587694f09c4c5cc82ec3e80424cdce93ea2d99a783b447cfed5c640dba854a1417d6e2a576c7f403210b4c63a13e57495ff8f4ce11f",
+        "sha1": "afbb670dbcd40221ffafa53f7116d9db14a6bd03"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/OnlVIpq5/versions/sKqtVH3Z/zfastnoise-1.0.29-ocl%2B26.1.2.jar"
+      ],
+      "fileSize": 463226
+    },
+    {
+      "path": "mods/BadOptimizations-2.4.1-26.1-fabric.jar",
+      "hashes": {
+        "sha1": "9636073ca8f378ea796b5d13bffac146a7f2f0f3",
+        "sha512": "efba144dec306767da3aceb4b179e093daa60bc4c0ba6295d64c166092b8f62e4a4cc63a5bae76fb4c608f1dffa8ecd70c6884e48c804915e1b37ef042e31a99"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/gjIvugXc/BadOptimizations-2.4.1-26.1-fabric.jar"
+      ],
+      "fileSize": 61928
+    },
+    {
+      "path": "mods/ScalableLux-0.2.0+fabric.2b63825-all.jar",
+      "hashes": {
+        "sha512": "48565a4d8a1cbd623f0044086d971f2c0cf1c40e1d0b6636a61d41512f4c1c1ddff35879d9dba24b088a670ee254e2d5842d13a30b6d76df23706fa94ea4a58b",
+        "sha1": "3875a697a9bb014c06aa3a62d72e8bec3de23160"
       },
       "env": {
         "server": "required",
         "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/Ps1zyz6x/versions/gYbHVCz8/ScalableLux-0.2.0%2Bfabric.2b63825-all.jar"
+      ],
+      "fileSize": 183504
+    },
+    {
+      "path": "mods/c2me-fabric-mc26.1.2-0.3.7+alpha.0.65.jar",
+      "hashes": {
+        "sha512": "6666ebaa3bfa403e386776590fc845b7c306107d37ebc7b1be3b057893fbf9f933abb2314c171d7fe19c177cf8823cb47fdc32040d34a9704f5ab656dd5d93f8",
+        "sha1": "b2ad88cbe82f510d178726e6304f575892b53878"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/VSNURh3q/versions/yrNQQ1AQ/c2me-fabric-mc26.1.2-0.3.7%2Balpha.0.65.jar"
+      ],
+      "fileSize": 4728926
+    },
+    {
+      "path": "mods/modernfix-5.27.5-build.2.jar",
+      "hashes": {
+        "sha512": "1ac2938e1cabe026ef667d6556874e1125ace2df1d0c0cd73fa6ee6224cd8850d00a2a92c90aa7ae9881c71a3dda628a18128fa7ce5fcd89247eadef6771c741",
+        "sha1": "2a52e6878e4c0237d0a2a45af47fb65342904199"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/TjSm1wrD/versions/5REDoIHm/modernfix-5.27.5-build.2.jar"
@@ -21,10 +81,70 @@
       "fileSize": 680612
     },
     {
+      "path": "mods/entityculling-fabric-1.10.1-mc26.1.jar",
+      "hashes": {
+        "sha512": "028bfa99f6eda39f78fa8b700a95d6b05c0349545560596176291efe69c3d0061642c7af5b8063e326e1b311de3b055e10efcae1ed254075baf2d91c6921c011",
+        "sha1": "17829d606ef5b73be4b206e5a465f8fb4e526fd5"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/NNAgCjsB/versions/NaRJu6ah/entityculling-fabric-1.10.1-mc26.1.jar"
+      ],
+      "fileSize": 1563254
+    },
+    {
+      "path": "mods/ImmediatelyFast-Fabric-1.15.2+26.1.2.jar",
+      "hashes": {
+        "sha1": "195bc6059dda0aac574906d035fae0b62a575a87",
+        "sha512": "46371d0958d705182e0945a0bd93b750a07a1f32a4f3189d85741804392137a47790d3bd0e341e7e9d5bf2783652598575ae1dc26f188aa9a71758f9d568e709"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/5ZwdcRci/versions/lRuSLf0Y/ImmediatelyFast-Fabric-1.15.2%2B26.1.2.jar"
+      ],
+      "fileSize": 304946
+    },
+    {
+      "path": "mods/sodium-fabric-0.8.9+mc26.1.1.jar",
+      "hashes": {
+        "sha1": "48b949ec71365788dfd4e89d489f7abd504aa709",
+        "sha512": "74f9dc8963b5258226837cc361ba6b525da734ab4fa5f05d1862bc6e9175f4fa81ca3d49443e2fb85be144d06042f0d65cbcceefc391043af857b38aa2614ae8"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/AANobbMI/versions/uGvVQBnw/sodium-fabric-0.8.9%2Bmc26.1.1.jar"
+      ],
+      "fileSize": 1810286
+    },
+    {
+      "path": "mods/cloth-config-26.1.154.jar",
+      "hashes": {
+        "sha1": "832f9047bc4af13587709c74f7c37e1c8579d1eb",
+        "sha512": "8bfb75f2cac0a9910316c6a368a228c0f8f1261ac6f03dec5fba594e1619ac04334a3df4fb29778d61d0b8290d55949371a523d722b35501bf9a2902956d3b17"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/9s6osm5g/versions/GFM8zh9J/cloth-config-26.1.154.jar"
+      ],
+      "fileSize": 1135373
+    },
+    {
       "path": "mods/lithium-fabric-0.24.2+mc26.1.2.jar",
       "hashes": {
-        "sha1": "a2575886c93255a73e5c583e89332b8bd56023d3",
-        "sha512": "9231ad05667d4eef0348c700bf5160929e0b723d9e145fd97c7fcef9387ac2e6d524fb15d99f47f8f838f1d235324fd750cdcb6603b63aab6085d79fbeaab31b"
+        "sha512": "9231ad05667d4eef0348c700bf5160929e0b723d9e145fd97c7fcef9387ac2e6d524fb15d99f47f8f838f1d235324fd750cdcb6603b63aab6085d79fbeaab31b",
+        "sha1": "a2575886c93255a73e5c583e89332b8bd56023d3"
       },
       "env": {
         "client": "required",
@@ -36,49 +156,19 @@
       "fileSize": 882624
     },
     {
-      "path": "mods/cloth-config-26.1.154.jar",
+      "path": "mods/moreculling-fabric-26.1.1-1.7.0-beta.5.jar",
       "hashes": {
-        "sha512": "8bfb75f2cac0a9910316c6a368a228c0f8f1261ac6f03dec5fba594e1619ac04334a3df4fb29778d61d0b8290d55949371a523d722b35501bf9a2902956d3b17",
-        "sha1": "832f9047bc4af13587709c74f7c37e1c8579d1eb"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/9s6osm5g/versions/GFM8zh9J/cloth-config-26.1.154.jar"
-      ],
-      "fileSize": 1135373
-    },
-    {
-      "path": "mods/c2me-fabric-mc26.1.2-0.3.7+alpha.0.65.jar",
-      "hashes": {
-        "sha1": "b2ad88cbe82f510d178726e6304f575892b53878",
-        "sha512": "6666ebaa3bfa403e386776590fc845b7c306107d37ebc7b1be3b057893fbf9f933abb2314c171d7fe19c177cf8823cb47fdc32040d34a9704f5ab656dd5d93f8"
+        "sha512": "57556eb3280637c5666e0a4e93d8b92912848ba7804014d56f73e1363b3e1f7b272f5641cd08420123b9bf68ec9c5d71c2314ba3e4c5d69e5c4e00f0e925ddd8",
+        "sha1": "7831be27edaf8581c6bba15867b2a47f4ee9b625"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/VSNURh3q/versions/yrNQQ1AQ/c2me-fabric-mc26.1.2-0.3.7%2Balpha.0.65.jar"
+        "https://cdn.modrinth.com/data/51shyZVL/versions/KJBkanxk/moreculling-fabric-26.1.1-1.7.0-beta.5.jar"
       ],
-      "fileSize": 4728926
-    },
-    {
-      "path": "mods/entityculling-fabric-1.10.1-mc26.1.jar",
-      "hashes": {
-        "sha1": "17829d606ef5b73be4b206e5a465f8fb4e526fd5",
-        "sha512": "028bfa99f6eda39f78fa8b700a95d6b05c0349545560596176291efe69c3d0061642c7af5b8063e326e1b311de3b055e10efcae1ed254075baf2d91c6921c011"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/NNAgCjsB/versions/NaRJu6ah/entityculling-fabric-1.10.1-mc26.1.jar"
-      ],
-      "fileSize": 1563254
+      "fileSize": 358073
     },
     {
       "path": "mods/fabric-api-0.146.1+26.1.2.jar",
@@ -111,55 +201,10 @@
       "fileSize": 692374
     },
     {
-      "path": "mods/ScalableLux-0.2.0+fabric.2b63825-all.jar",
-      "hashes": {
-        "sha512": "48565a4d8a1cbd623f0044086d971f2c0cf1c40e1d0b6636a61d41512f4c1c1ddff35879d9dba24b088a670ee254e2d5842d13a30b6d76df23706fa94ea4a58b",
-        "sha1": "3875a697a9bb014c06aa3a62d72e8bec3de23160"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/Ps1zyz6x/versions/gYbHVCz8/ScalableLux-0.2.0%2Bfabric.2b63825-all.jar"
-      ],
-      "fileSize": 183504
-    },
-    {
-      "path": "mods/sodium-fabric-0.8.9+mc26.1.1.jar",
-      "hashes": {
-        "sha512": "74f9dc8963b5258226837cc361ba6b525da734ab4fa5f05d1862bc6e9175f4fa81ca3d49443e2fb85be144d06042f0d65cbcceefc391043af857b38aa2614ae8",
-        "sha1": "48b949ec71365788dfd4e89d489f7abd504aa709"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/AANobbMI/versions/uGvVQBnw/sodium-fabric-0.8.9%2Bmc26.1.1.jar"
-      ],
-      "fileSize": 1810286
-    },
-    {
-      "path": "mods/moreculling-fabric-26.1.1-1.7.0-beta.5.jar",
-      "hashes": {
-        "sha512": "57556eb3280637c5666e0a4e93d8b92912848ba7804014d56f73e1363b3e1f7b272f5641cd08420123b9bf68ec9c5d71c2314ba3e4c5d69e5c4e00f0e925ddd8",
-        "sha1": "7831be27edaf8581c6bba15867b2a47f4ee9b625"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/51shyZVL/versions/KJBkanxk/moreculling-fabric-26.1.1-1.7.0-beta.5.jar"
-      ],
-      "fileSize": 358073
-    },
-    {
       "path": "mods/ferritecore-9.0.0-fabric.jar",
       "hashes": {
-        "sha512": "d81fa97e11784c19d42f89c2f433831d007603dd7193cee45fa177e4a6a9c52b384b198586e04a0f7f63cd996fed713322578bde9a8db57e1188854ae5cbe584",
-        "sha1": "eac76ff0f3753422c61b2c44487d0d195d88d4bc"
+        "sha1": "eac76ff0f3753422c61b2c44487d0d195d88d4bc",
+        "sha512": "d81fa97e11784c19d42f89c2f433831d007603dd7193cee45fa177e4a6a9c52b384b198586e04a0f7f63cd996fed713322578bde9a8db57e1188854ae5cbe584"
       },
       "env": {
         "client": "required",
@@ -169,51 +214,6 @@
         "https://cdn.modrinth.com/data/uXXizFIs/versions/d5ddUdiB/ferritecore-9.0.0-fabric.jar"
       ],
       "fileSize": 72677
-    },
-    {
-      "path": "mods/BadOptimizations-2.4.1-26.1-fabric.jar",
-      "hashes": {
-        "sha1": "9636073ca8f378ea796b5d13bffac146a7f2f0f3",
-        "sha512": "efba144dec306767da3aceb4b179e093daa60bc4c0ba6295d64c166092b8f62e4a4cc63a5bae76fb4c608f1dffa8ecd70c6884e48c804915e1b37ef042e31a99"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/gjIvugXc/BadOptimizations-2.4.1-26.1-fabric.jar"
-      ],
-      "fileSize": 61928
-    },
-    {
-      "path": "mods/ImmediatelyFast-Fabric-1.15.2+26.1.2.jar",
-      "hashes": {
-        "sha1": "195bc6059dda0aac574906d035fae0b62a575a87",
-        "sha512": "46371d0958d705182e0945a0bd93b750a07a1f32a4f3189d85741804392137a47790d3bd0e341e7e9d5bf2783652598575ae1dc26f188aa9a71758f9d568e709"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/5ZwdcRci/versions/lRuSLf0Y/ImmediatelyFast-Fabric-1.15.2%2B26.1.2.jar"
-      ],
-      "fileSize": 304946
-    },
-    {
-      "path": "mods/noisium-fabric-2.8.4+mc26.1-pre-2.jar",
-      "hashes": {
-        "sha512": "757f3e4f5271f221a715df3c27c5da5f5c9612dbfba2a298cbda9381de1b832524ae676868839a6c93cb88612181a8ed5ab5f848e0fa768ac0750c1c38a88636",
-        "sha1": "3ca0f8a504a80dcd084a5c6f801beda50d67db08"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/hasdd01q/versions/QWyo5TsS/noisium-fabric-2.8.4%2Bmc26.1-pre-2.jar"
-      ],
-      "fileSize": 70336
     }
   ],
   "dependencies": {

--- a/export/NeoForge/26.1.2/modrinth.index.json
+++ b/export/NeoForge/26.1.2/modrinth.index.json
@@ -1,39 +1,129 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "0.1.0",
+  "versionId": "0.2.0",
   "name": "Photon",
   "summary": "",
   "files": [
     {
-      "path": "mods/ImmediatelyFast-NeoForge-1.15.2+26.1.2.jar",
+      "path": "mods/ScalableLux-0.2.0+neoforge.cd0897f-all.jar",
       "hashes": {
-        "sha512": "9a6090db04d641ac8abd424d502c1b5b252ea5b0c076ca2e1acc5673ce54420d503e61119295945ff19f61ebc59fd9c473d44fb9dd1808b9cedfa1d37bd3f7a3",
-        "sha1": "e2c52c4161bf50215eb2fa68f6d90371d89471e3"
+        "sha512": "70b51e28306be4fb44f433d048512289b90151e1494b99f05093be051668cb8273963eaa7437155d387e0ed6b8a85f7f5ff272c75980d3afd5061776a56a9650",
+        "sha1": "51c10122d4c752649f1ce16bb12a3f1a9ae00f5f"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/5ZwdcRci/versions/KibcXkbk/ImmediatelyFast-NeoForge-1.15.2%2B26.1.2.jar"
+        "https://cdn.modrinth.com/data/Ps1zyz6x/versions/yUKGUtvc/ScalableLux-0.2.0%2Bneoforge.cd0897f-all.jar"
       ],
-      "fileSize": 326948
+      "fileSize": 184270
     },
     {
-      "path": "mods/Ixeris-4.1.8+26.1.1-neoforge.jar",
+      "path": "mods/c2me-neoforge-mc26.1.1-0.3.7+alpha.0.85.jar",
       "hashes": {
-        "sha1": "3d0699399a7310c79e9205bc1635946d105da023",
-        "sha512": "1193e31b08508f372e81b91dc90f68962229be2d4b718c49b9e752722a0fa08b7ecccfc6b1a09355e7e5a7ec561896e841947db388e79bcc85e92d1c3d571f98"
+        "sha1": "a6028052353d0117e5d787e2cf373eb22a363308",
+        "sha512": "173d3cc6cb2f65d15402883a547fa8ad3cef883645e04571ed0a202bc66e0158042b9c2a94b6ae49a709a8da35a12b2ef9d2239eae16f4c8883a21cbff1649b0"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/COlSi5iR/versions/hh7yJLE9/c2me-neoforge-mc26.1.1-0.3.7%2Balpha.0.85.jar"
+      ],
+      "fileSize": 4529068
+    },
+    {
+      "path": "mods/lithium-neoforge-0.24.2+mc26.1.2.jar",
+      "hashes": {
+        "sha512": "3af3dbcb49184069b74a9ada72857421fcd2c660fbbc4b29513130eb9b546dbbce81b92fdf13eb07ae5cccee546aa5e8c3b02a944bbcb838c5cea9d0a40a6d74",
+        "sha1": "a0af9187cec37b0b33c569e6b19d8cfe7a7fa1f8"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/p8RJPJIC/versions/MlqBc7yc/Ixeris-4.1.8%2B26.1.1-neoforge.jar"
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/ZVNWRJdi/lithium-neoforge-0.24.2%2Bmc26.1.2.jar"
       ],
-      "fileSize": 612565
+      "fileSize": 874078
+    },
+    {
+      "path": "mods/BadOptimizations-2.4.1-26.1-forge.jar",
+      "hashes": {
+        "sha512": "7f79fe81896c383744298055bebae8c46420d429fccf1453388a20bcc3cca6fa6ae1e5f1bfb12f10b05be7d648cc17ad3270460fb6099287a6c826b303d3ef9a",
+        "sha1": "5365e900361a589158965ab2b8bd7fd83c107c7e"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/MZd0Pqsf/BadOptimizations-2.4.1-26.1-forge.jar"
+      ],
+      "fileSize": 62720
+    },
+    {
+      "path": "mods/Ixeris-4.1.10+26.1.2-neoforge.jar",
+      "hashes": {
+        "sha512": "8d1d1f0021998d21ea8bb46ae25f6674a571c6f13828bbd1214987acfd4f35c7071d9daea853f7ae0a2e7edb73128226e3ea47ee01c196706e42428293300af0",
+        "sha1": "3f51d295d62c86943ffac95176a0da882316b5ef"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/Y3SOeXC9/Ixeris-4.1.10%2B26.1.2-neoforge.jar"
+      ],
+      "fileSize": 614117
+    },
+    {
+      "path": "mods/zfastnoise-1.0.29+26.1.2+neoforge.jar",
+      "hashes": {
+        "sha1": "3aaf90afd934283ab1b55b80832e5bb2f374c3f5",
+        "sha512": "93d015bdd501103836c446836a820e744e7451b01cf4748e07e95a79f18426513d404e1d47d118093c5a9f84992d69fb05bfe21a04c249e3bbf158c08a424666"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/OnlVIpq5/versions/x9WogrY9/zfastnoise-1.0.29%2B26.1.2%2Bneoforge.jar"
+      ],
+      "fileSize": 706635
+    },
+    {
+      "path": "mods/ferritecore-9.0.0-neoforge.jar",
+      "hashes": {
+        "sha512": "e96a99ac5539f56a1f4cd109d62b668ebd5283f0068491ede956f52e67023beba7abe2e40021499352ffc41ead950bebcabce7792352249a1b45c5dccb3cf99c",
+        "sha1": "b8bfb14ba6ce7068aae08c3a132ca40bda6bd143"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/uXXizFIs/versions/LtVvw4uS/ferritecore-9.0.0-neoforge.jar"
+      ],
+      "fileSize": 71947
+    },
+    {
+      "path": "mods/ImmediatelyFast-NeoForge-1.15.2+26.1.2.jar",
+      "hashes": {
+        "sha1": "e2c52c4161bf50215eb2fa68f6d90371d89471e3",
+        "sha512": "9a6090db04d641ac8abd424d502c1b5b252ea5b0c076ca2e1acc5673ce54420d503e61119295945ff19f61ebc59fd9c473d44fb9dd1808b9cedfa1d37bd3f7a3"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/5ZwdcRci/versions/KibcXkbk/ImmediatelyFast-NeoForge-1.15.2%2B26.1.2.jar"
+      ],
+      "fileSize": 326948
     },
     {
       "path": "mods/cloth-config-26.1.154.jar",
@@ -51,64 +141,19 @@
       "fileSize": 1135993
     },
     {
-      "path": "mods/modernfix-neoforge-5.27.5+mc26.1.2.jar",
+      "path": "mods/moreculling-neoforge-26.1.1-1.7.0-beta.5.jar",
       "hashes": {
-        "sha512": "3706c820b1355f892cc007ead807abab271ea594b0cda2ef525cc1a292fab85b52e1b1b870fbcec9668d154a9747bd323ed642e0b78eb5c515474967364eaafe",
-        "sha1": "75a5cf9c3d1e1af955ac24cf2d462eb0d443c97e"
+        "sha512": "40847b74b0c4c14aecbb6ae56f56427dc8743cf76c92945e9d3d2bff7ef249104098502a90339b44ab95a0b0e76960f533e06b3bfcea2ca7f9ad9d9bfa437248",
+        "sha1": "5e62f0e0b6083371f4aee9d83073f286a6dfb1ed"
       },
       "env": {
-        "client": "required",
-        "server": "required"
+        "server": "required",
+        "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/nmDcB62a/versions/1MM4Ok3r/modernfix-neoforge-5.27.5%2Bmc26.1.2.jar"
+        "https://cdn.modrinth.com/data/51shyZVL/versions/Y9lhHBQk/moreculling-neoforge-26.1.1-1.7.0-beta.5.jar"
       ],
-      "fileSize": 471678
-    },
-    {
-      "path": "mods/ferritecore-9.0.0-neoforge.jar",
-      "hashes": {
-        "sha1": "b8bfb14ba6ce7068aae08c3a132ca40bda6bd143",
-        "sha512": "e96a99ac5539f56a1f4cd109d62b668ebd5283f0068491ede956f52e67023beba7abe2e40021499352ffc41ead950bebcabce7792352249a1b45c5dccb3cf99c"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/uXXizFIs/versions/LtVvw4uS/ferritecore-9.0.0-neoforge.jar"
-      ],
-      "fileSize": 71947
-    },
-    {
-      "path": "mods/c2me-neoforge-mc26.1.1-0.3.7+alpha.0.85.jar",
-      "hashes": {
-        "sha1": "a6028052353d0117e5d787e2cf373eb22a363308",
-        "sha512": "173d3cc6cb2f65d15402883a547fa8ad3cef883645e04571ed0a202bc66e0158042b9c2a94b6ae49a709a8da35a12b2ef9d2239eae16f4c8883a21cbff1649b0"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/COlSi5iR/versions/hh7yJLE9/c2me-neoforge-mc26.1.1-0.3.7%2Balpha.0.85.jar"
-      ],
-      "fileSize": 4529068
-    },
-    {
-      "path": "mods/ScalableLux-0.2.0+neoforge.cd0897f-all.jar",
-      "hashes": {
-        "sha1": "51c10122d4c752649f1ce16bb12a3f1a9ae00f5f",
-        "sha512": "70b51e28306be4fb44f433d048512289b90151e1494b99f05093be051668cb8273963eaa7437155d387e0ed6b8a85f7f5ff272c75980d3afd5061776a56a9650"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/Ps1zyz6x/versions/yUKGUtvc/ScalableLux-0.2.0%2Bneoforge.cd0897f-all.jar"
-      ],
-      "fileSize": 184270
+      "fileSize": 351156
     },
     {
       "path": "mods/sodium-neoforge-0.8.9+mc26.1.1.jar",
@@ -126,53 +171,23 @@
       "fileSize": 1121322
     },
     {
-      "path": "mods/BadOptimizations-2.4.1-26.1-forge.jar",
+      "path": "mods/modernfix-neoforge-5.27.6+mc26.1.2.jar",
       "hashes": {
-        "sha1": "5365e900361a589158965ab2b8bd7fd83c107c7e",
-        "sha512": "7f79fe81896c383744298055bebae8c46420d429fccf1453388a20bcc3cca6fa6ae1e5f1bfb12f10b05be7d648cc17ad3270460fb6099287a6c826b303d3ef9a"
+        "sha512": "5ef67aa4c8a84b947b85a7a9f5dff7ed2c7e24b563704acd439501871e8cce8e7901dbf37133db3c7bb92736ec3be7664540442ec8ae4f177a75682152034b7a",
+        "sha1": "2aabe782aa8334a0a05c68de13dc999ae5a27736"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/MZd0Pqsf/BadOptimizations-2.4.1-26.1-forge.jar"
+        "https://cdn.modrinth.com/data/nmDcB62a/versions/uIned7g2/modernfix-neoforge-5.27.6%2Bmc26.1.2.jar"
       ],
-      "fileSize": 62720
-    },
-    {
-      "path": "mods/lithium-neoforge-0.24.1+mc26.1.2.jar",
-      "hashes": {
-        "sha512": "eb43bdc95af6bae25c91f0a6dfaa9ac7b684df2450faa6618df115bb5688589b9b53956c5dc0887ebca13431d8d89dfedcebace52fbc8b4bcb6b5ede169a1717",
-        "sha1": "296aec461d9e412e458da00a0c0846864d4562a5"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/Q8n3OtlQ/lithium-neoforge-0.24.1%2Bmc26.1.2.jar"
-      ],
-      "fileSize": 875846
-    },
-    {
-      "path": "mods/moreculling-neoforge-26.1.1-1.7.0-beta.5.jar",
-      "hashes": {
-        "sha1": "5e62f0e0b6083371f4aee9d83073f286a6dfb1ed",
-        "sha512": "40847b74b0c4c14aecbb6ae56f56427dc8743cf76c92945e9d3d2bff7ef249104098502a90339b44ab95a0b0e76960f533e06b3bfcea2ca7f9ad9d9bfa437248"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/51shyZVL/versions/Y9lhHBQk/moreculling-neoforge-26.1.1-1.7.0-beta.5.jar"
-      ],
-      "fileSize": 351156
+      "fileSize": 472193
     }
   ],
   "dependencies": {
-    "minecraft": "26.1.2",
-    "neoforge": "26.1.2.9-beta"
+    "neoforge": "26.1.2.9-beta",
+    "minecraft": "26.1.2"
   }
 }

--- a/export/Quilt/1.19.4/modrinth.index.json
+++ b/export/Quilt/1.19.4/modrinth.index.json
@@ -1,10 +1,55 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "1.1.13",
+  "versionId": "1.2.0",
   "name": "Photon",
   "summary": "",
   "files": [
+    {
+      "path": "mods/ImmediatelyFast-Fabric-1.2.11+1.19.4.jar",
+      "hashes": {
+        "sha512": "c7b3443406357bad283d2214f4f99ff8760a60c60c228b2e40acc33e37409be87c3e7eebd4d33f460dd2697a25188361f8869a96e5cb2d34422a6107248d2e85",
+        "sha1": "956a23c27590dd14195128708cd6e59b057a10dc"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/5ZwdcRci/versions/ezKTj0NE/ImmediatelyFast-Fabric-1.2.11%2B1.19.4.jar"
+      ],
+      "fileSize": 370128
+    },
+    {
+      "path": "mods/zfastnoise-1.0.11+1.19.4.jar",
+      "hashes": {
+        "sha512": "4f3a78109274959171db0504a39301fa492c90b34665be047fac4478922f18c23cef07eed5cdbf8de886d5022f4bf7ebdf951930d2b83e6c1ed8ba5a710dfc30",
+        "sha1": "9ea0bfbc3c222cb04aa65e5a67473922f8d69058"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/OnlVIpq5/versions/ih5xzhim/zfastnoise-1.0.11%2B1.19.4.jar"
+      ],
+      "fileSize": 34592
+    },
+    {
+      "path": "mods/enhancedblockentities-0.9+1.19.4.jar",
+      "hashes": {
+        "sha1": "97ffe54d7f5294fe6c8b529f51ef4b208b3ab1a7",
+        "sha512": "a60cbef0fc67789fafefafaf799107e17b96a2d1cf67f3b8396f8960a64308c9a9d33c822a0d62f6873bf2215c2026c46b78fa2d240c0055148230f13903636d"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/OVuFYfre/versions/Xdo5ZiRc/enhancedblockentities-0.9%2B1.19.4.jar"
+      ],
+      "fileSize": 492518
+    },
     {
       "path": "mods/lithium-fabric-mc1.19.4-0.11.1.jar",
       "hashes": {
@@ -12,8 +57,8 @@
         "sha1": "69aa137957af4f0f701f6a7663c6d8646f84a1cc"
       },
       "env": {
-        "server": "required",
-        "client": "required"
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/gvQqBUqZ/versions/14hWYkog/lithium-fabric-mc1.19.4-0.11.1.jar"
@@ -21,10 +66,55 @@
       "fileSize": 639391
     },
     {
+      "path": "mods/sodium-fabric-mc1.19.4-0.4.10+build.24.jar",
+      "hashes": {
+        "sha1": "b060680929d7a6d130fb980a9f9907461df05fa1",
+        "sha512": "61562626870aa4067657d2687d1fce80fb7d62af32fd68a22708e24ee5b84b39d16b26ccf4db8f53f2da42ba1916d6a5e11efc476cb5c2a8644207659fd5dfef"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/AANobbMI/versions/b4hTi3mo/sodium-fabric-mc1.19.4-0.4.10%2Bbuild.24.jar"
+      ],
+      "fileSize": 711302
+    },
+    {
+      "path": "mods/c2me-fabric-mc1.19.4-0.2.0+alpha.10.66.jar",
+      "hashes": {
+        "sha512": "1cbb1fe9b3538d953e341b499c67001f9fb142bf24853a6133dbc091aa8757d47d9949a1bc04106676cfb0b3ac280409fe017c1e3d4194bf35bb606eaea6c79d",
+        "sha1": "5c681eb7358d91faf52c7b57d590c4fa274a6847"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/VSNURh3q/versions/uZ1nQtIu/c2me-fabric-mc1.19.4-0.2.0%2Balpha.10.66.jar"
+      ],
+      "fileSize": 1298898
+    },
+    {
+      "path": "mods/entityculling-fabric-1.10.1-mc1.19.4.jar",
+      "hashes": {
+        "sha512": "fd40094a4e89ba8329d5611ecb98aad86171f322925d674845fc0836f75d4ab4bb86b97cdf8647cfeac39fb43065955628d3cf6a4722eadbabed8004e53abe2d",
+        "sha1": "72f9353f728efee75827af32aabe014fd2fa0167"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/NNAgCjsB/versions/6mDhobgd/entityculling-fabric-1.10.1-mc1.19.4.jar"
+      ],
+      "fileSize": 1575871
+    },
+    {
       "path": "mods/cloth-config-10.1.135-fabric.jar",
       "hashes": {
-        "sha512": "b9aed46cff0bb4f33b55632de2234efc223d406cb33f264fc52048965c3570ae03d2493c5a93f46efd3bcf8c13f1d9cb420ff567f6c768108ddacb60918efbe6",
-        "sha1": "4f180acffa5c4abb1ed895c21265dc50b1420dff"
+        "sha1": "4f180acffa5c4abb1ed895c21265dc50b1420dff",
+        "sha512": "b9aed46cff0bb4f33b55632de2234efc223d406cb33f264fc52048965c3570ae03d2493c5a93f46efd3bcf8c13f1d9cb420ff567f6c768108ddacb60918efbe6"
       },
       "env": {
         "client": "required",
@@ -36,79 +126,34 @@
       "fileSize": 1171035
     },
     {
-      "path": "mods/sodium-fabric-mc1.19.4-0.4.10+build.24.jar",
+      "path": "mods/Ixeris-4.1.10+1.20.1-fabric.jar",
       "hashes": {
-        "sha512": "61562626870aa4067657d2687d1fce80fb7d62af32fd68a22708e24ee5b84b39d16b26ccf4db8f53f2da42ba1916d6a5e11efc476cb5c2a8644207659fd5dfef",
-        "sha1": "b060680929d7a6d130fb980a9f9907461df05fa1"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/AANobbMI/versions/b4hTi3mo/sodium-fabric-mc1.19.4-0.4.10%2Bbuild.24.jar"
-      ],
-      "fileSize": 711302
-    },
-    {
-      "path": "mods/qfapi-6.0.0-beta.11_qsl-5.0.0-beta.11_fapi-0.87.0_mc-1.19.4.jar",
-      "hashes": {
-        "sha1": "ee5bbcae4ba9231b53fc317e5fd4bf8352b6de8b",
-        "sha512": "803b437084b698be11686cfda1e8056236e3a82126454a43927c9a5a5ae22f4cb2f0aaab50ffdd6dd04bb1e89fba9b81bb10867ae7a96884b4fa016974a4c0c5"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/qvIfYCYJ/versions/BQoiDT9n/qfapi-6.0.0-beta.11_qsl-5.0.0-beta.11_fapi-0.87.0_mc-1.19.4.jar"
-      ],
-      "fileSize": 1901471
-    },
-    {
-      "path": "mods/modernfix-fabric-5.7.2+mc1.19.4.jar",
-      "hashes": {
-        "sha1": "53ec153757699d3998f74891d8ac8ef13b3da2aa",
-        "sha512": "94877c4253224855753650e198df5cec908e4d07ae8f678982fa0a51a421d8f5659c2d505320a6af079da890bddca4f17d519484411bba877ca67fe545ec58b8"
+        "sha1": "e477095f3c09758623a729fd1ca439cac180016c",
+        "sha512": "1d0f35e45d3d10d1d6d5a1df18ade64be36c6aa7dfc3626175dec6c78e54129e8fc31f7b7c02ebcafeafba683835ab2bca4d7908f74b00060c1eb660d7c0d8e4"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/nmDcB62a/versions/LXlsO4Vo/modernfix-fabric-5.7.2%2Bmc1.19.4.jar"
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/oBuFEwH4/Ixeris-4.1.10%2B1.20.1-fabric.jar"
       ],
-      "fileSize": 513020
+      "fileSize": 704470
     },
     {
-      "path": "mods/Ixeris-4.1.8+1.20.1-fabric.jar",
+      "path": "mods/phosphor-fabric-mc1.19.x-0.8.1.jar",
       "hashes": {
-        "sha512": "83659b0d157079836e083ea72c4397b12f8ea93aaf492640603010fb6ddfec793568755decdce0c81745564734e624b40d43a1ec4e1e680e8f903be8b18c5e12",
-        "sha1": "6ee6404893d8655a2327c7c2423f381c0b4f6794"
+        "sha1": "2dd6f771ba5878d81892b9487f35340e94c87a1c",
+        "sha512": "13a0707b7a92726aa3154bc40978f36bb340d643c1d60e9fa2cbf8f7b0c7d3ea03c2a079f46a487df05e944eec9f5779afae9e99be7f70373e8a31d59948d487"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/p8RJPJIC/versions/K6CavRla/Ixeris-4.1.8%2B1.20.1-fabric.jar"
+        "https://cdn.modrinth.com/data/hEOCdOgW/versions/mc1.19.x-0.8.1/phosphor-fabric-mc1.19.x-0.8.1.jar"
       ],
-      "fileSize": 702782
-    },
-    {
-      "path": "mods/indium-1.0.19+mc1.19.4.jar",
-      "hashes": {
-        "sha512": "676e217ba05ff49c3e8d5d801f7c157b5b988eb21a44694d5c72a279dcdfe30933f57639a66d9f49b9b10c26edb288e8aa212ba27d4bd9abe0212c52b2e9b193",
-        "sha1": "55638e279d8a19ea5df67ff86feb6350e95376e1"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/Orvt0mRa/versions/oYQsfz9e/indium-1.0.19%2Bmc1.19.4.jar"
-      ],
-      "fileSize": 104841
+      "fileSize": 88018
     },
     {
       "path": "mods/moreculling-1.19.4-0.17.0.jar",
@@ -126,29 +171,14 @@
       "fileSize": 1235479
     },
     {
-      "path": "mods/enhancedblockentities-0.9+1.19.4.jar",
-      "hashes": {
-        "sha512": "a60cbef0fc67789fafefafaf799107e17b96a2d1cf67f3b8396f8960a64308c9a9d33c822a0d62f6873bf2215c2026c46b78fa2d240c0055148230f13903636d",
-        "sha1": "97ffe54d7f5294fe6c8b529f51ef4b208b3ab1a7"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/OVuFYfre/versions/Xdo5ZiRc/enhancedblockentities-0.9%2B1.19.4.jar"
-      ],
-      "fileSize": 492518
-    },
-    {
       "path": "mods/BadOptimizations-2.1.4-1.19.4.jar",
       "hashes": {
         "sha1": "330c0dd1f933d4ae5911cddc04324541dd0aea07",
         "sha512": "2455f656b056a1e3365a90079a03ef16c0a0bb10571f2ad10f0870f16c55cb32c838d0ecfadc35726b28ee768522dadb80cd3a43aeb878fadcd348405741ee75"
       },
       "env": {
-        "server": "required",
-        "client": "required"
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/g96Z4WVZ/versions/xhGlhCut/BadOptimizations-2.1.4-1.19.4.jar"
@@ -156,64 +186,19 @@
       "fileSize": 422943
     },
     {
-      "path": "mods/entityculling-fabric-1.10.1-mc1.19.4.jar",
+      "path": "mods/indium-1.0.19+mc1.19.4.jar",
       "hashes": {
-        "sha512": "fd40094a4e89ba8329d5611ecb98aad86171f322925d674845fc0836f75d4ab4bb86b97cdf8647cfeac39fb43065955628d3cf6a4722eadbabed8004e53abe2d",
-        "sha1": "72f9353f728efee75827af32aabe014fd2fa0167"
+        "sha1": "55638e279d8a19ea5df67ff86feb6350e95376e1",
+        "sha512": "676e217ba05ff49c3e8d5d801f7c157b5b988eb21a44694d5c72a279dcdfe30933f57639a66d9f49b9b10c26edb288e8aa212ba27d4bd9abe0212c52b2e9b193"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/NNAgCjsB/versions/6mDhobgd/entityculling-fabric-1.10.1-mc1.19.4.jar"
+        "https://cdn.modrinth.com/data/Orvt0mRa/versions/oYQsfz9e/indium-1.0.19%2Bmc1.19.4.jar"
       ],
-      "fileSize": 1575871
-    },
-    {
-      "path": "mods/ImmediatelyFast-Fabric-1.2.11+1.19.4.jar",
-      "hashes": {
-        "sha1": "956a23c27590dd14195128708cd6e59b057a10dc",
-        "sha512": "c7b3443406357bad283d2214f4f99ff8760a60c60c228b2e40acc33e37409be87c3e7eebd4d33f460dd2697a25188361f8869a96e5cb2d34422a6107248d2e85"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/5ZwdcRci/versions/ezKTj0NE/ImmediatelyFast-Fabric-1.2.11%2B1.19.4.jar"
-      ],
-      "fileSize": 370128
-    },
-    {
-      "path": "mods/c2me-fabric-mc1.19.4-0.2.0+alpha.10.66.jar",
-      "hashes": {
-        "sha1": "5c681eb7358d91faf52c7b57d590c4fa274a6847",
-        "sha512": "1cbb1fe9b3538d953e341b499c67001f9fb142bf24853a6133dbc091aa8757d47d9949a1bc04106676cfb0b3ac280409fe017c1e3d4194bf35bb606eaea6c79d"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/VSNURh3q/versions/uZ1nQtIu/c2me-fabric-mc1.19.4-0.2.0%2Balpha.10.66.jar"
-      ],
-      "fileSize": 1298898
-    },
-    {
-      "path": "mods/phosphor-fabric-mc1.19.x-0.8.1.jar",
-      "hashes": {
-        "sha512": "13a0707b7a92726aa3154bc40978f36bb340d643c1d60e9fa2cbf8f7b0c7d3ea03c2a079f46a487df05e944eec9f5779afae9e99be7f70373e8a31d59948d487",
-        "sha1": "2dd6f771ba5878d81892b9487f35340e94c87a1c"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/hEOCdOgW/versions/mc1.19.x-0.8.1/phosphor-fabric-mc1.19.x-0.8.1.jar"
-      ],
-      "fileSize": 88018
+      "fileSize": 104841
     },
     {
       "path": "mods/ferritecore-5.2.0-fabric.jar",
@@ -222,13 +207,43 @@
         "sha1": "ed6fa9a9365d4e58db6703479a44cc6aed5add2f"
       },
       "env": {
-        "server": "required",
-        "client": "required"
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/uXXizFIs/versions/RbR7EG8T/ferritecore-5.2.0-fabric.jar"
       ],
       "fileSize": 124924
+    },
+    {
+      "path": "mods/qfapi-6.0.0-beta.11_qsl-5.0.0-beta.11_fapi-0.87.0_mc-1.19.4.jar",
+      "hashes": {
+        "sha512": "803b437084b698be11686cfda1e8056236e3a82126454a43927c9a5a5ae22f4cb2f0aaab50ffdd6dd04bb1e89fba9b81bb10867ae7a96884b4fa016974a4c0c5",
+        "sha1": "ee5bbcae4ba9231b53fc317e5fd4bf8352b6de8b"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/qvIfYCYJ/versions/BQoiDT9n/qfapi-6.0.0-beta.11_qsl-5.0.0-beta.11_fapi-0.87.0_mc-1.19.4.jar"
+      ],
+      "fileSize": 1901471
+    },
+    {
+      "path": "mods/modernfix-fabric-5.7.2+mc1.19.4.jar",
+      "hashes": {
+        "sha512": "94877c4253224855753650e198df5cec908e4d07ae8f678982fa0a51a421d8f5659c2d505320a6af079da890bddca4f17d519484411bba877ca67fe545ec58b8",
+        "sha1": "53ec153757699d3998f74891d8ac8ef13b3da2aa"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/nmDcB62a/versions/LXlsO4Vo/modernfix-fabric-5.7.2%2Bmc1.19.4.jar"
+      ],
+      "fileSize": 513020
     }
   ],
   "dependencies": {

--- a/export/Quilt/1.20.1/modrinth.index.json
+++ b/export/Quilt/1.20.1/modrinth.index.json
@@ -1,24 +1,24 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "1.1.17",
+  "versionId": "1.2.0",
   "name": "Photon",
   "summary": "",
   "files": [
     {
-      "path": "mods/indium-1.0.36+mc1.20.1.jar",
+      "path": "mods/qfapi-7.7.0_qsl-6.3.0_fapi-0.92.2_mc-1.20.1.jar",
       "hashes": {
-        "sha1": "d824614e7a173d273167969f427702f51846aca7",
-        "sha512": "7c5a1851f1fc08ae69318e151d07151fabba6cda2a24616c9251e1a4e5b969453e88b97d60f926271d60e3511bfc6fa05a64a108466efb7f29bec4519547e0c9"
+        "sha512": "d7bb384b961088ae6fe1e0baef9895cd495a515d8337664bb534c36ae17e48188fc1c50cd9a06e3e53898870ada73e737f63853adf43e744fee11a64bad1059a",
+        "sha1": "fa2868388b175e32e4d3310a5bf065593837bc5c"
       },
       "env": {
-        "server": "required",
-        "client": "required"
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/Orvt0mRa/versions/nQHYSjxO/indium-1.0.36%2Bmc1.20.1.jar"
+        "https://cdn.modrinth.com/data/qvIfYCYJ/versions/s8dfz9Xa/qfapi-7.7.0_qsl-6.3.0_fapi-0.92.2_mc-1.20.1.jar"
       ],
-      "fileSize": 105382
+      "fileSize": 2755789
     },
     {
       "path": "mods/c2me-fabric-mc1.20.1-0.2.0+alpha.11.16.jar",
@@ -36,51 +36,6 @@
       "fileSize": 1426500
     },
     {
-      "path": "mods/cloth-config-11.1.136-fabric.jar",
-      "hashes": {
-        "sha512": "2da85c071c854223cc30c8e46794391b77e53f28ecdbbde59dc83b3dbbdfc74be9e68da9ed464e7f98b4361033899ba4f681ebff1f35edc2c60e599a59796f1c",
-        "sha1": "d5fe84a0cc9ed5c7290a76ba570e1f8716afecab"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/9s6osm5g/versions/2xQdCMyG/cloth-config-11.1.136-fabric.jar"
-      ],
-      "fileSize": 1172214
-    },
-    {
-      "path": "mods/noisium-fabric-2.3.0+mc1.20-1.20.1.jar",
-      "hashes": {
-        "sha1": "be85535cf1efe82bd8c41bcf851becaad498a598",
-        "sha512": "f0abcdac514bd2b4eb6af3529eeb9980a6fef534d31244879acb291a9943151aeb34f372bf98ae01f6191870bf95e1c0bc36d522433353a1090b96e7ac03c417"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/KuNKN7d2/versions/erSJnRcq/noisium-fabric-2.3.0%2Bmc1.20-1.20.1.jar"
-      ],
-      "fileSize": 214902
-    },
-    {
-      "path": "mods/lithium-fabric-mc1.20.1-0.11.4.jar",
-      "hashes": {
-        "sha512": "31938b7e849609892ffa1710e41f2e163d11876f824452540658c4b53cd13c666dbdad8d200989461932bd9952814c5943e64252530c72bdd5d8641775151500",
-        "sha1": "048227ed60a3005cf9fa55880dfe0cf20b0ba680"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/iEcXOkz4/lithium-fabric-mc1.20.1-0.11.4.jar"
-      ],
-      "fileSize": 691483
-    },
-    {
       "path": "mods/modernfix-fabric-5.25.2+mc1.20.1.jar",
       "hashes": {
         "sha1": "be03b9eb570c1e9df7593e68623f0fecbd039460",
@@ -96,14 +51,104 @@
       "fileSize": 545175
     },
     {
+      "path": "mods/cloth-config-11.1.136-fabric.jar",
+      "hashes": {
+        "sha512": "2da85c071c854223cc30c8e46794391b77e53f28ecdbbde59dc83b3dbbdfc74be9e68da9ed464e7f98b4361033899ba4f681ebff1f35edc2c60e599a59796f1c",
+        "sha1": "d5fe84a0cc9ed5c7290a76ba570e1f8716afecab"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/9s6osm5g/versions/2xQdCMyG/cloth-config-11.1.136-fabric.jar"
+      ],
+      "fileSize": 1172214
+    },
+    {
+      "path": "mods/lithium-fabric-mc1.20.1-0.11.4.jar",
+      "hashes": {
+        "sha1": "048227ed60a3005cf9fa55880dfe0cf20b0ba680",
+        "sha512": "31938b7e849609892ffa1710e41f2e163d11876f824452540658c4b53cd13c666dbdad8d200989461932bd9952814c5943e64252530c72bdd5d8641775151500"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/iEcXOkz4/lithium-fabric-mc1.20.1-0.11.4.jar"
+      ],
+      "fileSize": 691483
+    },
+    {
+      "path": "mods/moreculling-1.20.1-0.24.5.jar",
+      "hashes": {
+        "sha1": "5110436d5f7867033744d2c065c44986730d79aa",
+        "sha512": "1d4a2009f55c45f5215ec9858525a8d97180c713a669afef4dd76c06e8ec134049c7cb7d4799ddd4938c2a4b1b76c8c734f7759dad42fe588d2dbc546598b0eb"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/51shyZVL/versions/3wkuUDPy/moreculling-1.20.1-0.24.5.jar"
+      ],
+      "fileSize": 274506
+    },
+    {
+      "path": "mods/zfastnoise-1.0.11+1.20.jar",
+      "hashes": {
+        "sha512": "c4e229524e309b67bdf6916c6770a2e63a20986b973874e6dd26ecb7e7f1ee4016e2283fd277cf49b597244510b6cea249c882cf6d518105ebfa566e9733b32b",
+        "sha1": "0c70551779487d7ae4e535b640f4da9c711e7612"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/OnlVIpq5/versions/dKwaus8G/zfastnoise-1.0.11%2B1.20.jar"
+      ],
+      "fileSize": 34590
+    },
+    {
+      "path": "mods/Ixeris-4.1.10+1.20.1-fabric.jar",
+      "hashes": {
+        "sha1": "e477095f3c09758623a729fd1ca439cac180016c",
+        "sha512": "1d0f35e45d3d10d1d6d5a1df18ade64be36c6aa7dfc3626175dec6c78e54129e8fc31f7b7c02ebcafeafba683835ab2bca4d7908f74b00060c1eb660d7c0d8e4"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/oBuFEwH4/Ixeris-4.1.10%2B1.20.1-fabric.jar"
+      ],
+      "fileSize": 704470
+    },
+    {
+      "path": "mods/enhancedblockentities-0.9+1.20.jar",
+      "hashes": {
+        "sha512": "7e8b402fd25efd396bc7f0f25a663808ae9890accc227850c454dfcdc975657f22afceb15878e781485622434a6f6d60aff2a60264aa4425edd52ebe052a0de5",
+        "sha1": "61cfe50f69f8ef9e3640c0269ef158870f5b0410"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/OVuFYfre/versions/i3v1Skck/enhancedblockentities-0.9%2B1.20.jar"
+      ],
+      "fileSize": 490690
+    },
+    {
       "path": "mods/BadOptimizations-2.4.1-1.20.1.jar",
       "hashes": {
         "sha1": "304007dcb0fb15ed1a1bc3771736470dafc5be0f",
         "sha512": "5e02d9c5a5bc3dccfccbfac4809cda4eb755c015060063b696e92568e0be3d8354a01f6ac5dae99bd27111b7e20bb680512287119459ad069dcf3e7d17cace0f"
       },
       "env": {
-        "client": "required",
-        "server": "required"
+        "server": "required",
+        "client": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/g96Z4WVZ/versions/DIugITgU/BadOptimizations-2.4.1-1.20.1.jar"
@@ -126,44 +171,14 @@
       "fileSize": 125197
     },
     {
-      "path": "mods/sodium-fabric-0.5.13+mc1.20.1.jar",
+      "path": "mods/ImmediatelyFast-Fabric-1.5.4+1.20.4.jar",
       "hashes": {
-        "sha1": "bcdbf37d9494e405cba210d7a80ed58e756297b5",
-        "sha512": "81c64f9c2d3402dfa43ee54d8f5a054f5243bfb08984e3addcab9fe885073c79c43c1c8c41e8f30b625d26a656f82a8e5f370bbbbf222ff1c08f4b324edb7ea4"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/AANobbMI/versions/OihdIimA/sodium-fabric-0.5.13%2Bmc1.20.1.jar"
-      ],
-      "fileSize": 971552
-    },
-    {
-      "path": "mods/enhancedblockentities-0.9+1.20.jar",
-      "hashes": {
-        "sha1": "61cfe50f69f8ef9e3640c0269ef158870f5b0410",
-        "sha512": "7e8b402fd25efd396bc7f0f25a663808ae9890accc227850c454dfcdc975657f22afceb15878e781485622434a6f6d60aff2a60264aa4425edd52ebe052a0de5"
+        "sha512": "9efa25c2062ce24ef78716c8244f89a5d393ec9f937b165ffaec2aa8c9be664acbf7168e5739a237520c59c573861a39e374fe94c35321400039ba85be4ff2a5",
+        "sha1": "bb9e7a507bb7a442cba451d79b5c1fde74aea07c"
       },
       "env": {
         "client": "required",
         "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/OVuFYfre/versions/i3v1Skck/enhancedblockentities-0.9%2B1.20.jar"
-      ],
-      "fileSize": 490690
-    },
-    {
-      "path": "mods/ImmediatelyFast-Fabric-1.5.4+1.20.4.jar",
-      "hashes": {
-        "sha1": "bb9e7a507bb7a442cba451d79b5c1fde74aea07c",
-        "sha512": "9efa25c2062ce24ef78716c8244f89a5d393ec9f937b165ffaec2aa8c9be664acbf7168e5739a237520c59c573861a39e374fe94c35321400039ba85be4ff2a5"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/5ZwdcRci/versions/Us8JqrP9/ImmediatelyFast-Fabric-1.5.4%2B1.20.4.jar"
@@ -186,49 +201,34 @@
       "fileSize": 1575495
     },
     {
-      "path": "mods/qfapi-7.7.0_qsl-6.3.0_fapi-0.92.2_mc-1.20.1.jar",
+      "path": "mods/indium-1.0.36+mc1.20.1.jar",
       "hashes": {
-        "sha1": "fa2868388b175e32e4d3310a5bf065593837bc5c",
-        "sha512": "d7bb384b961088ae6fe1e0baef9895cd495a515d8337664bb534c36ae17e48188fc1c50cd9a06e3e53898870ada73e737f63853adf43e744fee11a64bad1059a"
+        "sha512": "7c5a1851f1fc08ae69318e151d07151fabba6cda2a24616c9251e1a4e5b969453e88b97d60f926271d60e3511bfc6fa05a64a108466efb7f29bec4519547e0c9",
+        "sha1": "d824614e7a173d273167969f427702f51846aca7"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/qvIfYCYJ/versions/s8dfz9Xa/qfapi-7.7.0_qsl-6.3.0_fapi-0.92.2_mc-1.20.1.jar"
+        "https://cdn.modrinth.com/data/Orvt0mRa/versions/nQHYSjxO/indium-1.0.36%2Bmc1.20.1.jar"
       ],
-      "fileSize": 2755789
+      "fileSize": 105382
     },
     {
-      "path": "mods/moreculling-1.20.1-0.24.5.jar",
+      "path": "mods/sodium-fabric-0.5.13+mc1.20.1.jar",
       "hashes": {
-        "sha1": "5110436d5f7867033744d2c065c44986730d79aa",
-        "sha512": "1d4a2009f55c45f5215ec9858525a8d97180c713a669afef4dd76c06e8ec134049c7cb7d4799ddd4938c2a4b1b76c8c734f7759dad42fe588d2dbc546598b0eb"
+        "sha512": "81c64f9c2d3402dfa43ee54d8f5a054f5243bfb08984e3addcab9fe885073c79c43c1c8c41e8f30b625d26a656f82a8e5f370bbbbf222ff1c08f4b324edb7ea4",
+        "sha1": "bcdbf37d9494e405cba210d7a80ed58e756297b5"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/51shyZVL/versions/3wkuUDPy/moreculling-1.20.1-0.24.5.jar"
+        "https://cdn.modrinth.com/data/AANobbMI/versions/OihdIimA/sodium-fabric-0.5.13%2Bmc1.20.1.jar"
       ],
-      "fileSize": 274506
-    },
-    {
-      "path": "mods/Ixeris-4.1.8+1.20.1-fabric.jar",
-      "hashes": {
-        "sha1": "6ee6404893d8655a2327c7c2423f381c0b4f6794",
-        "sha512": "83659b0d157079836e083ea72c4397b12f8ea93aaf492640603010fb6ddfec793568755decdce0c81745564734e624b40d43a1ec4e1e680e8f903be8b18c5e12"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/p8RJPJIC/versions/K6CavRla/Ixeris-4.1.8%2B1.20.1-fabric.jar"
-      ],
-      "fileSize": 702782
+      "fileSize": 971552
     }
   ],
   "dependencies": {

--- a/export/Quilt/1.20.4/modrinth.index.json
+++ b/export/Quilt/1.20.4/modrinth.index.json
@@ -1,135 +1,30 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "1.1.16",
+  "versionId": "1.2.0",
   "name": "Photon",
   "summary": "",
   "files": [
     {
-      "path": "mods/lithium-fabric-mc1.20.4-0.12.1.jar",
+      "path": "mods/zfastnoise-1.0.11+1.20.jar",
       "hashes": {
-        "sha512": "70bea154eaafb2e4b5cb755cdb12c55d50f9296ab4c2855399da548f72d6d24c0a9f77e3da2b2ea5f47fa91d1258df4d08c6c6f24a25da887ed71cea93502508",
-        "sha1": "4a0744beb2246d93cb475d21a5a53faa556956e0"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/nMhjKWVE/lithium-fabric-mc1.20.4-0.12.1.jar"
-      ],
-      "fileSize": 716022
-    },
-    {
-      "path": "mods/indium-1.0.31+mc1.20.4.jar",
-      "hashes": {
-        "sha512": "27b4a73ca990742e27eee4348553c86c96c19fddcd0763892029f67ddbde42dc03c0ac21230403ae6b4ce4da315d0d49f582d3daab413b9ea84fd6d172ee7c4f",
-        "sha1": "fe6d0513ac332d890f1bd9bb9354a8e240b8f0e5"
+        "sha512": "c4e229524e309b67bdf6916c6770a2e63a20986b973874e6dd26ecb7e7f1ee4016e2283fd277cf49b597244510b6cea249c882cf6d518105ebfa566e9733b32b",
+        "sha1": "0c70551779487d7ae4e535b640f4da9c711e7612"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/Orvt0mRa/versions/VlLxDisa/indium-1.0.31%2Bmc1.20.4.jar"
+        "https://cdn.modrinth.com/data/OnlVIpq5/versions/dKwaus8G/zfastnoise-1.0.11%2B1.20.jar"
       ],
-      "fileSize": 105350
-    },
-    {
-      "path": "mods/quilted-fabric-api-9.0.0-alpha.8+0.97.0-1.20.4.jar",
-      "hashes": {
-        "sha512": "ae742daae860126d26a0397059345f8361880cf6330d0e38e078bc6bbd79da3bbaea10ff7b663db5d174075bcf9fc67a3a12d496fa86ac8849aecf0a3fea7da0",
-        "sha1": "34d0e558366a31d1dfc28fc7b6ae8f61d7b2ce11"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/qvIfYCYJ/versions/AljqyvST/quilted-fabric-api-9.0.0-alpha.8%2B0.97.0-1.20.4.jar"
-      ],
-      "fileSize": 1987276
-    },
-    {
-      "path": "mods/modernfix-fabric-5.17.0+mc1.20.4.jar",
-      "hashes": {
-        "sha512": "8404bc285100746ac76467094b2b4feb132e046272780c4c8a6d4bd4336fad70073734438e9f37bf7e46ffa65dbf2f06ab10232b09c3911c08215dfcf71fca0e",
-        "sha1": "cf5f1f0db74b0385c2738c6fbf8347e7e68100d6"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/nmDcB62a/versions/CV2Vtn5m/modernfix-fabric-5.17.0%2Bmc1.20.4.jar"
-      ],
-      "fileSize": 458056
-    },
-    {
-      "path": "mods/Ixeris-4.1.8+1.20.4-fabric.jar",
-      "hashes": {
-        "sha1": "7c3dcb5256e52e3029532dda151966ad12771190",
-        "sha512": "e3c89f5ff6cb4d59ed18c972e8dc2f267fed35d52dc2a17e77f464950cf12830206ab6286c1413d6ec3e69874d811dc92f360a7cd48bb466a37ca9d0f207b751"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/p8RJPJIC/versions/pQfTiOhJ/Ixeris-4.1.8%2B1.20.4-fabric.jar"
-      ],
-      "fileSize": 703014
-    },
-    {
-      "path": "mods/c2me-fabric-mc1.20.4-0.2.0+alpha.11.72.jar",
-      "hashes": {
-        "sha512": "bcc67b816ed01d67b5230d66f408223eb5c6d72f9fd500dab7c007a627d338491e0f1af4ba2929d35089ac9e22c9bc3a8eac48770c7c9aa7c78d70e453892ed1",
-        "sha1": "cb60c6a25b5a77fd57f18bb1fd978bb13601c6d5"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/VSNURh3q/versions/1AeveXNt/c2me-fabric-mc1.20.4-0.2.0%2Balpha.11.72.jar"
-      ],
-      "fileSize": 1289505
-    },
-    {
-      "path": "mods/enhancedblockentities-0.10.1+1.20.4.jar",
-      "hashes": {
-        "sha1": "f2b182c46486ecce3a2f84893efb1c1b9382e859",
-        "sha512": "36885e53d47764060a9fab5953f725c3fb82fa93285a6e5e01f44ffd4df105a9e2d9747ba15fe25462ce0b6909e99db447ef3ea5c0c1ea3a7007eec452adbb8f"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/OVuFYfre/versions/xUOoKrs2/enhancedblockentities-0.10.1%2B1.20.4.jar"
-      ],
-      "fileSize": 330603
-    },
-    {
-      "path": "mods/cloth-config-13.0.138-fabric.jar",
-      "hashes": {
-        "sha512": "3863fb95cc57526c6876cb60600f2e4282a5fa8d997d981e984da48f34be654cd0c5fc09e7d77079a393b2d7e3e48baabb756ad84ea58881b22ea771f43baa4a",
-        "sha1": "e374f80329cea3d73e10e31839fe79d5a4fc0b30"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/9s6osm5g/versions/2deYQULk/cloth-config-13.0.138-fabric.jar"
-      ],
-      "fileSize": 1154870
+      "fileSize": 34590
     },
     {
       "path": "mods/ferritecore-6.0.3-fabric.jar",
       "hashes": {
-        "sha1": "f2bbb773f4213d36201b76820f206e2a6f213c0c",
-        "sha512": "709ab6362dd1dcc432edd1e6c33aafba6f2d12be701bc14911107340f8ac2466779c4e57d8a303f0350c46478f23008e6eeca78e4eadedd0bdee63d4ae72ed9a"
+        "sha512": "709ab6362dd1dcc432edd1e6c33aafba6f2d12be701bc14911107340f8ac2466779c4e57d8a303f0350c46478f23008e6eeca78e4eadedd0bdee63d4ae72ed9a",
+        "sha1": "f2bbb773f4213d36201b76820f206e2a6f213c0c"
       },
       "env": {
         "server": "required",
@@ -141,25 +36,10 @@
       "fileSize": 125100
     },
     {
-      "path": "mods/moreculling-1.20.4-0.24.0.jar",
-      "hashes": {
-        "sha512": "3a8accedfa48ce86b4091ce7994d63b2c7d1f6654119a5dc8430bd7370084bf04801c71600bb2b1546a58aef972797048f86eebbff2a666905a86c2b1cf7632e",
-        "sha1": "a40f2aa346140a4fee2079d845c62ee87454bdb6"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/51shyZVL/versions/3m5znPWm/moreculling-1.20.4-0.24.0.jar"
-      ],
-      "fileSize": 272851
-    },
-    {
       "path": "mods/ImmediatelyFast-Fabric-1.5.4+1.20.4.jar",
       "hashes": {
-        "sha512": "9efa25c2062ce24ef78716c8244f89a5d393ec9f937b165ffaec2aa8c9be664acbf7168e5739a237520c59c573861a39e374fe94c35321400039ba85be4ff2a5",
-        "sha1": "bb9e7a507bb7a442cba451d79b5c1fde74aea07c"
+        "sha1": "bb9e7a507bb7a442cba451d79b5c1fde74aea07c",
+        "sha512": "9efa25c2062ce24ef78716c8244f89a5d393ec9f937b165ffaec2aa8c9be664acbf7168e5739a237520c59c573861a39e374fe94c35321400039ba85be4ff2a5"
       },
       "env": {
         "client": "required",
@@ -169,6 +49,21 @@
         "https://cdn.modrinth.com/data/5ZwdcRci/versions/Us8JqrP9/ImmediatelyFast-Fabric-1.5.4%2B1.20.4.jar"
       ],
       "fileSize": 354883
+    },
+    {
+      "path": "mods/entityculling-fabric-1.10.1-mc1.20.4.jar",
+      "hashes": {
+        "sha512": "b501d61653a699bef5c317e5543c3b834cea94387e3cb8db2e30f6bb801c97dbfe2c4c45a0016f475949a7938bb06f28126cb98224a593d6b84265e66f69f3a3",
+        "sha1": "fb59f60578a7c1d7311237a7003b3c64402ad3ed"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/NNAgCjsB/versions/BMyAHFy2/entityculling-fabric-1.10.1-mc1.20.4.jar"
+      ],
+      "fileSize": 1575249
     },
     {
       "path": "mods/BadOptimizations-2.4.1-1.20.2-20.4.jar",
@@ -186,29 +81,14 @@
       "fileSize": 306487
     },
     {
-      "path": "mods/noisium-fabric-2.3.0+mc1.20.2-1.20.4.jar",
-      "hashes": {
-        "sha512": "249cf90051e808a224a22b6d45812831793368297c5873512a25a7e5f4b866c3d2a625b04f74ed8d9987b6171e7cca085ed8d7a100336f395cc037f1493e0e2b",
-        "sha1": "31be12110ac95503676adfaca2d9ac179e8b2072"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/KuNKN7d2/versions/RmNpWBtf/noisium-fabric-2.3.0%2Bmc1.20.2-1.20.4.jar"
-      ],
-      "fileSize": 214908
-    },
-    {
       "path": "mods/sodium-fabric-0.5.8+mc1.20.4.jar",
       "hashes": {
         "sha1": "4c38d7b01660a27a98406767c613b3f28b6c9dfe",
         "sha512": "bd00b956bde1205171e744a6a3780e835fb6928eb667fb2b56467818c979fb1e8c82561380a71a7dbfa1516cd4b6cf9087ca99f1ae066da6d65af2c828b8d554"
       },
       "env": {
-        "client": "required",
-        "server": "required"
+        "server": "required",
+        "client": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/AANobbMI/versions/4GyXKCLd/sodium-fabric-0.5.8%2Bmc1.20.4.jar"
@@ -216,23 +96,143 @@
       "fileSize": 949085
     },
     {
-      "path": "mods/entityculling-fabric-1.10.1-mc1.20.4.jar",
+      "path": "mods/lithium-fabric-mc1.20.4-0.12.1.jar",
       "hashes": {
-        "sha1": "fb59f60578a7c1d7311237a7003b3c64402ad3ed",
-        "sha512": "b501d61653a699bef5c317e5543c3b834cea94387e3cb8db2e30f6bb801c97dbfe2c4c45a0016f475949a7938bb06f28126cb98224a593d6b84265e66f69f3a3"
+        "sha1": "4a0744beb2246d93cb475d21a5a53faa556956e0",
+        "sha512": "70bea154eaafb2e4b5cb755cdb12c55d50f9296ab4c2855399da548f72d6d24c0a9f77e3da2b2ea5f47fa91d1258df4d08c6c6f24a25da887ed71cea93502508"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/NNAgCjsB/versions/BMyAHFy2/entityculling-fabric-1.10.1-mc1.20.4.jar"
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/nMhjKWVE/lithium-fabric-mc1.20.4-0.12.1.jar"
       ],
-      "fileSize": 1575249
+      "fileSize": 716022
+    },
+    {
+      "path": "mods/quilted-fabric-api-9.0.0-alpha.8+0.97.0-1.20.4.jar",
+      "hashes": {
+        "sha1": "34d0e558366a31d1dfc28fc7b6ae8f61d7b2ce11",
+        "sha512": "ae742daae860126d26a0397059345f8361880cf6330d0e38e078bc6bbd79da3bbaea10ff7b663db5d174075bcf9fc67a3a12d496fa86ac8849aecf0a3fea7da0"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/qvIfYCYJ/versions/AljqyvST/quilted-fabric-api-9.0.0-alpha.8%2B0.97.0-1.20.4.jar"
+      ],
+      "fileSize": 1987276
+    },
+    {
+      "path": "mods/c2me-fabric-mc1.20.4-0.2.0+alpha.11.72.jar",
+      "hashes": {
+        "sha512": "bcc67b816ed01d67b5230d66f408223eb5c6d72f9fd500dab7c007a627d338491e0f1af4ba2929d35089ac9e22c9bc3a8eac48770c7c9aa7c78d70e453892ed1",
+        "sha1": "cb60c6a25b5a77fd57f18bb1fd978bb13601c6d5"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/VSNURh3q/versions/1AeveXNt/c2me-fabric-mc1.20.4-0.2.0%2Balpha.11.72.jar"
+      ],
+      "fileSize": 1289505
+    },
+    {
+      "path": "mods/enhancedblockentities-0.10.1+1.20.4.jar",
+      "hashes": {
+        "sha512": "36885e53d47764060a9fab5953f725c3fb82fa93285a6e5e01f44ffd4df105a9e2d9747ba15fe25462ce0b6909e99db447ef3ea5c0c1ea3a7007eec452adbb8f",
+        "sha1": "f2b182c46486ecce3a2f84893efb1c1b9382e859"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/OVuFYfre/versions/xUOoKrs2/enhancedblockentities-0.10.1%2B1.20.4.jar"
+      ],
+      "fileSize": 330603
+    },
+    {
+      "path": "mods/Ixeris-4.1.10+1.20.4-fabric.jar",
+      "hashes": {
+        "sha512": "dc0c2a028112a8b99d2afa30a9e3c83a79b89016de9d99d075a47c8f7819a3a97eafe2c343e279f79872cc553aba35c9bd6b18aa05e82d0546a247dff89fea24",
+        "sha1": "b68fe3e087d0b229b75146c5449bde7fe220e2a4"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/KWyYXMG2/Ixeris-4.1.10%2B1.20.4-fabric.jar"
+      ],
+      "fileSize": 704705
+    },
+    {
+      "path": "mods/cloth-config-13.0.138-fabric.jar",
+      "hashes": {
+        "sha1": "e374f80329cea3d73e10e31839fe79d5a4fc0b30",
+        "sha512": "3863fb95cc57526c6876cb60600f2e4282a5fa8d997d981e984da48f34be654cd0c5fc09e7d77079a393b2d7e3e48baabb756ad84ea58881b22ea771f43baa4a"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/9s6osm5g/versions/2deYQULk/cloth-config-13.0.138-fabric.jar"
+      ],
+      "fileSize": 1154870
+    },
+    {
+      "path": "mods/moreculling-1.20.4-0.24.0.jar",
+      "hashes": {
+        "sha1": "a40f2aa346140a4fee2079d845c62ee87454bdb6",
+        "sha512": "3a8accedfa48ce86b4091ce7994d63b2c7d1f6654119a5dc8430bd7370084bf04801c71600bb2b1546a58aef972797048f86eebbff2a666905a86c2b1cf7632e"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/51shyZVL/versions/3m5znPWm/moreculling-1.20.4-0.24.0.jar"
+      ],
+      "fileSize": 272851
+    },
+    {
+      "path": "mods/modernfix-fabric-5.17.0+mc1.20.4.jar",
+      "hashes": {
+        "sha512": "8404bc285100746ac76467094b2b4feb132e046272780c4c8a6d4bd4336fad70073734438e9f37bf7e46ffa65dbf2f06ab10232b09c3911c08215dfcf71fca0e",
+        "sha1": "cf5f1f0db74b0385c2738c6fbf8347e7e68100d6"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/nmDcB62a/versions/CV2Vtn5m/modernfix-fabric-5.17.0%2Bmc1.20.4.jar"
+      ],
+      "fileSize": 458056
+    },
+    {
+      "path": "mods/indium-1.0.31+mc1.20.4.jar",
+      "hashes": {
+        "sha1": "fe6d0513ac332d890f1bd9bb9354a8e240b8f0e5",
+        "sha512": "27b4a73ca990742e27eee4348553c86c96c19fddcd0763892029f67ddbde42dc03c0ac21230403ae6b4ce4da315d0d49f582d3daab413b9ea84fd6d172ee7c4f"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/Orvt0mRa/versions/VlLxDisa/indium-1.0.31%2Bmc1.20.4.jar"
+      ],
+      "fileSize": 105350
     }
   ],
   "dependencies": {
-    "quilt-loader": "0.29.2",
-    "minecraft": "1.20.4"
+    "minecraft": "1.20.4",
+    "quilt-loader": "0.29.2"
   }
 }

--- a/export/Quilt/1.21.1/modrinth.index.json
+++ b/export/Quilt/1.21.1/modrinth.index.json
@@ -1,120 +1,45 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "1.2.17",
+  "versionId": "1.3.0",
   "name": "Photon",
   "summary": "",
   "files": [
     {
-      "path": "mods/lithium-fabric-0.15.3+mc1.21.1.jar",
+      "path": "mods/fabric-api-0.116.11+1.21.1.jar",
       "hashes": {
-        "sha1": "c4a1c2b6de9915ac77ae46a005509d4acf09535d",
-        "sha512": "8c576d519121b0c2521101d2209eccd85d560b097fcb847aa54c51cd0d3f3947676f01c8d99913f514487c8e0972a1cf5f3da0c9ef0ec9bacdf2baeb4eb7d1a7"
+        "sha1": "65f4e8b9dcbad6697b2fb32fa0bb937ec5efcd84",
+        "sha512": "756b8c086f4c911d012f2eb70ca792aef0439503b31bc52026b82830870a94d472de30d61a6a0a9988c02b8462d9c47aa6baa6cd84da1eaf00edb77249b3c413"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/XQJtuOTA/lithium-fabric-0.15.3%2Bmc1.21.1.jar"
+        "https://cdn.modrinth.com/data/P7dR8mSH/versions/IpaMcBLh/fabric-api-0.116.11%2B1.21.1.jar"
       ],
-      "fileSize": 797398
+      "fileSize": 2426356
     },
     {
-      "path": "mods/c2me-fabric-mc1.21.1-0.3.0+alpha.0.362.jar",
+      "path": "mods/moreculling-fabric-1.21.1-1.0.7.jar",
       "hashes": {
-        "sha1": "9beac89c94f36a342cb07cd9fcb42608bdd07771",
-        "sha512": "8653a751eb2ad1ad70da38017ccad0ee2bda5448ffe405d28049f09a61936765303f63ba4fcff798f32bb1e6b4645e892c275515b69c98c1730e24caab0ba7e0"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/VSNURh3q/versions/DSqOVCaF/c2me-fabric-mc1.21.1-0.3.0%2Balpha.0.362.jar"
-      ],
-      "fileSize": 4701117
-    },
-    {
-      "path": "mods/Ixeris-4.1.8+1.21.1-fabric.jar",
-      "hashes": {
-        "sha512": "ad5735114659b95abdf18607929e27e6b1ccc6cd25cabc7686817ff6711164b0991c20eadbf21b332306c64106cc8b995323fbeab167f9a4271d7ca48264aa7e",
-        "sha1": "a91c59cf0497b1a026bfee4912ab40f29133f4b2"
+        "sha1": "733ba14a0b780c76ffef5935a512aedb8e1bef60",
+        "sha512": "780abe790ff8b6ecaf22527a0be632147263c9729abf5db6aa4c50aabee76c00fa8516d92f204064b3bae44bdfc1b94ffb8c86201f36152dae8311c7173501d5"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/p8RJPJIC/versions/89N9zJWk/Ixeris-4.1.8%2B1.21.1-fabric.jar"
+        "https://cdn.modrinth.com/data/51shyZVL/versions/y4J2jK6V/moreculling-fabric-1.21.1-1.0.7.jar"
       ],
-      "fileSize": 702972
-    },
-    {
-      "path": "mods/sodium-fabric-0.6.13+mc1.21.1.jar",
-      "hashes": {
-        "sha512": "13032e064c554fc8671573dadb07bc70e6ea2f68706c65c086c4feb1d2f664346a3414cbf9d1367b42b8d063a35e40f2f967ef9af31642e1f0093b852161fe91",
-        "sha1": "928a2598178c3a58b0638bab842f467d2e49251a"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/AANobbMI/versions/u1OEbNKx/sodium-fabric-0.6.13%2Bmc1.21.1.jar"
-      ],
-      "fileSize": 1297761
-    },
-    {
-      "path": "mods/noisium-fabric-2.3.0+mc1.21-1.21.1.jar",
-      "hashes": {
-        "sha512": "606ba78cf7f30d99e417c96aa042f600c1b626ed9c783919496d139de650013f1434fcf93545782e3889660322837ce6e85530d9e1a5cc20f9ad161357ede43e",
-        "sha1": "642a672cfc60ff1e1262a39d7e160b1381c5120c"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/KuNKN7d2/versions/4sGQgiu2/noisium-fabric-2.3.0%2Bmc1.21-1.21.1.jar"
-      ],
-      "fileSize": 216183
-    },
-    {
-      "path": "mods/ferritecore-7.0.3-fabric.jar",
-      "hashes": {
-        "sha512": "3ad31620fac4ff44327dc7dedbe162b2d978f3f246dc16255a6e400ce9592a0d326fe36a626f3c1bf30a11f813093cbb4dcc107af039cff724d0cdf648541fdf",
-        "sha1": "a8a6a34fcda177da2828cedef44e0e538cf78aad"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/uXXizFIs/versions/sOzRw3CG/ferritecore-7.0.3-fabric.jar"
-      ],
-      "fileSize": 123450
-    },
-    {
-      "path": "mods/ImmediatelyFast-Fabric-1.6.10+1.21.1.jar",
-      "hashes": {
-        "sha1": "ff2be016b12128fc0cd875a21a307d681edde817",
-        "sha512": "7117aa1b27dd1d463707d4089aa52cc09619f32744bc33363b3515b705d9ce5039fd69190092d119552b73db30ad365dffc29f84f0af505d580cc5593d88e075"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/5ZwdcRci/versions/yHztKxR5/ImmediatelyFast-Fabric-1.6.10%2B1.21.1.jar"
-      ],
-      "fileSize": 342770
+      "fileSize": 346926
     },
     {
       "path": "mods/ScalableLux-0.1.0.1+fabric.d0d58ab-all.jar",
       "hashes": {
-        "sha512": "bbfe02184c3bf3b0da28175574a5a236ce7c9acc00069addd69770857f2ac572924893f3eb033bbbc965afa9779c7a7f8fc54168f9e90481a40de92f6ee3645f",
-        "sha1": "2ce889d9b1b210eef005ea03c3bbb39289c26e3f"
+        "sha1": "2ce889d9b1b210eef005ea03c3bbb39289c26e3f",
+        "sha512": "bbfe02184c3bf3b0da28175574a5a236ce7c9acc00069addd69770857f2ac572924893f3eb033bbbc965afa9779c7a7f8fc54168f9e90481a40de92f6ee3645f"
       },
       "env": {
         "server": "required",
@@ -126,55 +51,25 @@
       "fileSize": 177266
     },
     {
-      "path": "mods/moreculling-fabric-1.21.1-1.0.7.jar",
+      "path": "mods/zfastnoise-1.0.11+1.21.jar",
       "hashes": {
-        "sha512": "780abe790ff8b6ecaf22527a0be632147263c9729abf5db6aa4c50aabee76c00fa8516d92f204064b3bae44bdfc1b94ffb8c86201f36152dae8311c7173501d5",
-        "sha1": "733ba14a0b780c76ffef5935a512aedb8e1bef60"
+        "sha512": "16a8c997be7f14be0aeb08465a378cdc2ed2643b9a2d1f6a25dad44995d521dd16ac3809d2be79bc018d6abe9b5c051e653a230cc4a1bd8f2ebd76371e153a6e",
+        "sha1": "34a584c0e0bfa9d94cb7cd9c16b4e70ca1b30789"
       },
       "env": {
-        "client": "required",
-        "server": "required"
+        "server": "required",
+        "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/51shyZVL/versions/y4J2jK6V/moreculling-fabric-1.21.1-1.0.7.jar"
+        "https://cdn.modrinth.com/data/OnlVIpq5/versions/qETA8Qja/zfastnoise-1.0.11%2B1.21.jar"
       ],
-      "fileSize": 346926
-    },
-    {
-      "path": "mods/entityculling-fabric-1.10.1-mc1.21.1.jar",
-      "hashes": {
-        "sha512": "57c2db4458d64f47f28e0b753745ff0c62441372432f55454f4a626c3425b264663e0884edbb52e1f6b2545411425056707bd77cfeeac370b9a984f28c38c8c4",
-        "sha1": "6f7234ec1d50f563def59ab05ab44f62c119016b"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/NNAgCjsB/versions/umue6GAJ/entityculling-fabric-1.10.1-mc1.21.1.jar"
-      ],
-      "fileSize": 1574328
-    },
-    {
-      "path": "mods/BadOptimizations-2.4.1-1.21.1.jar",
-      "hashes": {
-        "sha1": "1461d8e46391efd32a3085150e86094c9f6f5c9d",
-        "sha512": "2b66428bd98bd5ec0e09f2ec6af801cefb7b9b99cc4f0993daeaffe8d0ccc5ee0c2a73e9f38d4f92540ead0181704d2c9e946837ec05cf710fc3b20fce3b0cac"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/S2qthD5S/BadOptimizations-2.4.1-1.21.1.jar"
-      ],
-      "fileSize": 283566
+      "fileSize": 34752
     },
     {
       "path": "mods/cloth-config-15.0.140-fabric.jar",
       "hashes": {
-        "sha1": "5d82342a2df53fd6df712bfdd583a811572918a4",
-        "sha512": "1b3f5db4fc1d481704053db9837d530919374bf7518d7cede607360f0348c04fc6347a3a72ccfef355559e1f4aef0b650cd58e5ee79c73b12ff0fc2746797a00"
+        "sha512": "1b3f5db4fc1d481704053db9837d530919374bf7518d7cede607360f0348c04fc6347a3a72ccfef355559e1f4aef0b650cd58e5ee79c73b12ff0fc2746797a00",
+        "sha1": "5d82342a2df53fd6df712bfdd583a811572918a4"
       },
       "env": {
         "client": "required",
@@ -186,19 +81,79 @@
       "fileSize": 1157166
     },
     {
-      "path": "mods/enhancedblockentities-0.10.2+1.21.jar",
+      "path": "mods/Ixeris-4.1.10+1.21.1-fabric.jar",
       "hashes": {
-        "sha1": "d81359d77fc7c5437f3e83e519dc2f869300f0cd",
-        "sha512": "60e01db603fcf1392c0cd5c3ce742e568f7d445d83fe60828b21f546e7d29fb6947231f22d28e29b07f4bdcb767b6dc2a2398b4decea665ecba1166690a44d49"
+        "sha1": "09c2b90bda6b4581a5c6fcdc9df562a8dee26418",
+        "sha512": "37671b9ab94a98d666552506773ed5850288b52e1c76da8978b0b3b4d5485df85817fcecd9abab3c0d833b4f13d6915797a309101203ac512e22aa240f4f5951"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/NBU1saZE/Ixeris-4.1.10%2B1.21.1-fabric.jar"
+      ],
+      "fileSize": 704662
+    },
+    {
+      "path": "mods/enhancedblockentities-0.10.2+1.21.jar",
+      "hashes": {
+        "sha1": "d81359d77fc7c5437f3e83e519dc2f869300f0cd",
+        "sha512": "60e01db603fcf1392c0cd5c3ce742e568f7d445d83fe60828b21f546e7d29fb6947231f22d28e29b07f4bdcb767b6dc2a2398b4decea665ecba1166690a44d49"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
         "https://cdn.modrinth.com/data/OVuFYfre/versions/HBZAPs3u/enhancedblockentities-0.10.2%2B1.21.jar"
       ],
       "fileSize": 201157
+    },
+    {
+      "path": "mods/ImmediatelyFast-Fabric-1.6.10+1.21.1.jar",
+      "hashes": {
+        "sha1": "ff2be016b12128fc0cd875a21a307d681edde817",
+        "sha512": "7117aa1b27dd1d463707d4089aa52cc09619f32744bc33363b3515b705d9ce5039fd69190092d119552b73db30ad365dffc29f84f0af505d580cc5593d88e075"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/5ZwdcRci/versions/yHztKxR5/ImmediatelyFast-Fabric-1.6.10%2B1.21.1.jar"
+      ],
+      "fileSize": 342770
+    },
+    {
+      "path": "mods/BadOptimizations-2.4.1-1.21.1.jar",
+      "hashes": {
+        "sha1": "1461d8e46391efd32a3085150e86094c9f6f5c9d",
+        "sha512": "2b66428bd98bd5ec0e09f2ec6af801cefb7b9b99cc4f0993daeaffe8d0ccc5ee0c2a73e9f38d4f92540ead0181704d2c9e946837ec05cf710fc3b20fce3b0cac"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/S2qthD5S/BadOptimizations-2.4.1-1.21.1.jar"
+      ],
+      "fileSize": 283566
+    },
+    {
+      "path": "mods/ferritecore-7.0.3-fabric.jar",
+      "hashes": {
+        "sha512": "3ad31620fac4ff44327dc7dedbe162b2d978f3f246dc16255a6e400ce9592a0d326fe36a626f3c1bf30a11f813093cbb4dcc107af039cff724d0cdf648541fdf",
+        "sha1": "a8a6a34fcda177da2828cedef44e0e538cf78aad"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/uXXizFIs/versions/sOzRw3CG/ferritecore-7.0.3-fabric.jar"
+      ],
+      "fileSize": 123450
     },
     {
       "path": "mods/modernfix-fabric-5.25.1+mc1.21.1.jar",
@@ -216,23 +171,68 @@
       "fileSize": 471258
     },
     {
-      "path": "mods/fabric-api-0.116.10+1.21.1.jar",
+      "path": "mods/sodium-fabric-0.6.13+mc1.21.1.jar",
       "hashes": {
-        "sha512": "cc8f207ca861e91c0d42f7d57b4448c2b265bbfb20f38182fad2dd14d3f4fbbbfa5c85b562ddaad33797f67fce8080b2283cdd6fa194f4ace18969d670643454",
-        "sha1": "22b506a0770f148f46737329e8cae68aaefe3165"
+        "sha1": "928a2598178c3a58b0638bab842f467d2e49251a",
+        "sha512": "13032e064c554fc8671573dadb07bc70e6ea2f68706c65c086c4feb1d2f664346a3414cbf9d1367b42b8d063a35e40f2f967ef9af31642e1f0093b852161fe91"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/P7dR8mSH/versions/ID8pq1x1/fabric-api-0.116.10%2B1.21.1.jar"
+        "https://cdn.modrinth.com/data/AANobbMI/versions/u1OEbNKx/sodium-fabric-0.6.13%2Bmc1.21.1.jar"
       ],
-      "fileSize": 2425988
+      "fileSize": 1297761
+    },
+    {
+      "path": "mods/entityculling-fabric-1.10.1-mc1.21.1.jar",
+      "hashes": {
+        "sha512": "57c2db4458d64f47f28e0b753745ff0c62441372432f55454f4a626c3425b264663e0884edbb52e1f6b2545411425056707bd77cfeeac370b9a984f28c38c8c4",
+        "sha1": "6f7234ec1d50f563def59ab05ab44f62c119016b"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/NNAgCjsB/versions/umue6GAJ/entityculling-fabric-1.10.1-mc1.21.1.jar"
+      ],
+      "fileSize": 1574328
+    },
+    {
+      "path": "mods/lithium-fabric-0.15.3+mc1.21.1.jar",
+      "hashes": {
+        "sha512": "8c576d519121b0c2521101d2209eccd85d560b097fcb847aa54c51cd0d3f3947676f01c8d99913f514487c8e0972a1cf5f3da0c9ef0ec9bacdf2baeb4eb7d1a7",
+        "sha1": "c4a1c2b6de9915ac77ae46a005509d4acf09535d"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/XQJtuOTA/lithium-fabric-0.15.3%2Bmc1.21.1.jar"
+      ],
+      "fileSize": 797398
+    },
+    {
+      "path": "mods/c2me-fabric-mc1.21.1-0.3.0+alpha.0.362.jar",
+      "hashes": {
+        "sha1": "9beac89c94f36a342cb07cd9fcb42608bdd07771",
+        "sha512": "8653a751eb2ad1ad70da38017ccad0ee2bda5448ffe405d28049f09a61936765303f63ba4fcff798f32bb1e6b4645e892c275515b69c98c1730e24caab0ba7e0"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/VSNURh3q/versions/DSqOVCaF/c2me-fabric-mc1.21.1-0.3.0%2Balpha.0.362.jar"
+      ],
+      "fileSize": 4701117
     }
   ],
   "dependencies": {
-    "quilt-loader": "0.29.2",
-    "minecraft": "1.21.1"
+    "minecraft": "1.21.1",
+    "quilt-loader": "0.29.2"
   }
 }

--- a/export/Quilt/1.21.11/modrinth.index.json
+++ b/export/Quilt/1.21.11/modrinth.index.json
@@ -1,69 +1,24 @@
 {
   "game": "minecraft",
   "formatVersion": 1,
-  "versionId": "1.0.4",
+  "versionId": "1.1.0",
   "name": "Photon",
   "summary": "",
   "files": [
     {
-      "path": "mods/modernfix-5.26.2-build.1.jar",
+      "path": "mods/BadOptimizations-2.4.1-1.21.11.jar",
       "hashes": {
-        "sha512": "d57be559b6d2ee802df3617a7d44586f690db27998cfc04f195ec645a754a9be9fcd7e824313671711b0e318720f39f0e96db46727a21ff17b4fa3187fbdf399",
-        "sha1": "959efa1690550b4e09616f808d5a5ee52c47477f"
+        "sha1": "70fa28d5a7a1fdd61dd804ca6ac411750da1473f",
+        "sha512": "ff91f1866f21a13a32d379080b8efb5d4e07577591228c1d307b34d052696c9bdcbaf7706208dfbac56abc2c29482a15edcbf11f69fc0a01e459c4c20a5c2c28"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/TjSm1wrD/versions/6q6pkhVP/modernfix-5.26.2-build.1.jar"
+        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/Q3Dusz2j/BadOptimizations-2.4.1-1.21.11.jar"
       ],
-      "fileSize": 627253
-    },
-    {
-      "path": "mods/entityculling-fabric-1.10.1-mc1.21.11.jar",
-      "hashes": {
-        "sha512": "93fac75432afb97f286827190b3e0363775e013946e22bc62cd86b1d0e0c10c1e7dbd520ca22a9445acb1f50afca38c12d41a4f9a4d3685218287bb7cad237b8",
-        "sha1": "4e595b6162d24c3d8d65bc6417cf79daac5bde0d"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/NNAgCjsB/versions/WORDhU8n/entityculling-fabric-1.10.1-mc1.21.11.jar"
-      ],
-      "fileSize": 1585638
-    },
-    {
-      "path": "mods/ScalableLux-0.1.6+fabric.c25518a-all.jar",
-      "hashes": {
-        "sha1": "9df93ab6442fa374c17fab6b5181fe2c215d9d5b",
-        "sha512": "729515c1e75cf8d9cd704f12b3487ddb9664cf9928e7b85b12289c8fbbc7ed82d0211e1851375cbd5b385820b4fedbc3f617038fff5e30b302047b0937042ae7"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/Ps1zyz6x/versions/PV9KcrYQ/ScalableLux-0.1.6%2Bfabric.c25518a-all.jar"
-      ],
-      "fileSize": 182846
-    },
-    {
-      "path": "mods/noisium-fabric-2.8.3+mc1.21.11.jar",
-      "hashes": {
-        "sha1": "2851c7824664bc970367f89710ffd569f49a761c",
-        "sha512": "03d4c116204ee8cb4f95b668576c9e8c099ed939c150ff0cf4ff094ae52b0c5f6214c1292c94f25ea7f614254151d1ff2db68ecaddc9f56486189d29fa3a24eb"
-      },
-      "env": {
-        "client": "required",
-        "server": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/hasdd01q/versions/VyMvRQKq/noisium-fabric-2.8.3%2Bmc1.21.11.jar"
-      ],
-      "fileSize": 225560
+      "fileSize": 269545
     },
     {
       "path": "mods/ferritecore-8.2.0-fabric.jar",
@@ -81,19 +36,64 @@
       "fileSize": 80138
     },
     {
-      "path": "mods/ImmediatelyFast-Fabric-1.14.2+1.21.11.jar",
+      "path": "mods/zfastnoise-1.0.29+1.21.11.jar",
       "hashes": {
-        "sha512": "dedff930a4e317994579020eaeef9f56d81d5215d871372d206fc974842d87e80e4be15d8571a4eaa4320c2412701ea093ba4494a47e8988e3d448ec8adcba37",
-        "sha1": "4f17c6b7388f0afc5d24075dc2a294963f78c712"
+        "sha1": "8c0b5ad24140bd91cdb8e4223d27620e641764c0",
+        "sha512": "18151ac6e803f7ff0ddcfc8680238ee052b0ae3fddafa8d2773a37de9965a41b8a0264591523f76361290ed40a44be6a448fb4d84e8e8a386a52f3292b9bc013"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/5ZwdcRci/versions/QwkfUKSj/ImmediatelyFast-Fabric-1.14.2%2B1.21.11.jar"
+        "https://cdn.modrinth.com/data/OnlVIpq5/versions/iokxBbTT/zfastnoise-1.0.29%2B1.21.11.jar"
       ],
-      "fileSize": 310445
+      "fileSize": 455559
+    },
+    {
+      "path": "mods/ScalableLux-0.1.6+fabric.c25518a-all.jar",
+      "hashes": {
+        "sha1": "9df93ab6442fa374c17fab6b5181fe2c215d9d5b",
+        "sha512": "729515c1e75cf8d9cd704f12b3487ddb9664cf9928e7b85b12289c8fbbc7ed82d0211e1851375cbd5b385820b4fedbc3f617038fff5e30b302047b0937042ae7"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/Ps1zyz6x/versions/PV9KcrYQ/ScalableLux-0.1.6%2Bfabric.c25518a-all.jar"
+      ],
+      "fileSize": 182846
+    },
+    {
+      "path": "mods/entityculling-fabric-1.10.1-mc1.21.11.jar",
+      "hashes": {
+        "sha1": "4e595b6162d24c3d8d65bc6417cf79daac5bde0d",
+        "sha512": "93fac75432afb97f286827190b3e0363775e013946e22bc62cd86b1d0e0c10c1e7dbd520ca22a9445acb1f50afca38c12d41a4f9a4d3685218287bb7cad237b8"
+      },
+      "env": {
+        "server": "required",
+        "client": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/NNAgCjsB/versions/WORDhU8n/entityculling-fabric-1.10.1-mc1.21.11.jar"
+      ],
+      "fileSize": 1585638
+    },
+    {
+      "path": "mods/Ixeris-4.1.10+1.21.11-fabric.jar",
+      "hashes": {
+        "sha1": "42c130c7b7c068dc3442ab2efb50e7c9930ae802",
+        "sha512": "38093de218550151db1ee0c9a6178d69f58db8886877c7744948b3e627455d6ebd25b173e2cf513376b0aac32329f50a8d1427a5bd513b72439ac5ae0ae98632"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/p8RJPJIC/versions/5VdrF7hS/Ixeris-4.1.10%2B1.21.11-fabric.jar"
+      ],
+      "fileSize": 705479
     },
     {
       "path": "mods/moreculling-fabric-1.21.11-1.6.2.jar",
@@ -102,13 +102,43 @@
         "sha1": "11a929de62650cc536244d4c2ba889fa84c1c0f2"
       },
       "env": {
-        "server": "required",
-        "client": "required"
+        "client": "required",
+        "server": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/51shyZVL/versions/wOzykoLV/moreculling-fabric-1.21.11-1.6.2.jar"
       ],
       "fileSize": 340975
+    },
+    {
+      "path": "mods/ImmediatelyFast-Fabric-1.14.2+1.21.11.jar",
+      "hashes": {
+        "sha1": "4f17c6b7388f0afc5d24075dc2a294963f78c712",
+        "sha512": "dedff930a4e317994579020eaeef9f56d81d5215d871372d206fc974842d87e80e4be15d8571a4eaa4320c2412701ea093ba4494a47e8988e3d448ec8adcba37"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/5ZwdcRci/versions/QwkfUKSj/ImmediatelyFast-Fabric-1.14.2%2B1.21.11.jar"
+      ],
+      "fileSize": 310445
+    },
+    {
+      "path": "mods/cloth-config-21.11.153-fabric.jar",
+      "hashes": {
+        "sha1": "4c224606a963bce223db5b27edb4959ecf40d4ee",
+        "sha512": "8f455489d4b71069e998568cf4e1450116f4360a4eb481cd89117f629c6883164886cf63ca08ac4fc929dd13d1112152755a6216d4a1498ee6406ef102093e51"
+      },
+      "env": {
+        "client": "required",
+        "server": "required"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/9s6osm5g/versions/xuX40TN5/cloth-config-21.11.153-fabric.jar"
+      ],
+      "fileSize": 1148427
     },
     {
       "path": "mods/c2me-fabric-mc1.21.11-0.3.6.0.0.jar",
@@ -126,64 +156,34 @@
       "fileSize": 4687147
     },
     {
-      "path": "mods/cloth-config-21.11.153-fabric.jar",
+      "path": "mods/lithium-fabric-0.21.4+mc1.21.11.jar",
       "hashes": {
-        "sha512": "8f455489d4b71069e998568cf4e1450116f4360a4eb481cd89117f629c6883164886cf63ca08ac4fc929dd13d1112152755a6216d4a1498ee6406ef102093e51",
-        "sha1": "4c224606a963bce223db5b27edb4959ecf40d4ee"
+        "sha512": "f14a5c3d2fad786347ca25083f902139694f618b7c103947f2fd067a7c5ee88a63e1ef8926f7d693ea79ed7d00f57317bae77ef9c2d630bf5ed01ac97a752b94",
+        "sha1": "203bdcb26e97b3217b045e1182651a7d7b6462ec"
       },
       "env": {
         "server": "required",
         "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/9s6osm5g/versions/xuX40TN5/cloth-config-21.11.153-fabric.jar"
+        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/Ow7wA0kG/lithium-fabric-0.21.4%2Bmc1.21.11.jar"
       ],
-      "fileSize": 1148427
+      "fileSize": 900462
     },
     {
       "path": "mods/sodium-fabric-0.8.7+mc1.21.11.jar",
       "hashes": {
-        "sha1": "e8865210ba9a926fc206ab9e73f9d4988a81ff69",
-        "sha512": "d7f035d6112eaac92cf0f11e4426db631fca5a7115dd355c2126efee4255b648a0102552bbf7b22a7eae9203d08f8740435842bfddcd94e2434f51b57ee9c641"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/AANobbMI/versions/UddlN6L4/sodium-fabric-0.8.7%2Bmc1.21.11.jar"
-      ],
-      "fileSize": 1870358
-    },
-    {
-      "path": "mods/Ixeris-4.1.8+1.21.11-fabric.jar",
-      "hashes": {
-        "sha512": "db9ceeccf89c2e0736133a4361c41c62a742befce55724f529faf870056eaedd89105dae3a1675ee1dc8bf633a6931e691c66ea966e2feadb5517febdf01b292",
-        "sha1": "a4bc219f61a33bc18b038cbebd8da0f7d7a0056c"
-      },
-      "env": {
-        "server": "required",
-        "client": "required"
-      },
-      "downloads": [
-        "https://cdn.modrinth.com/data/p8RJPJIC/versions/sVbnqVVv/Ixeris-4.1.8%2B1.21.11-fabric.jar"
-      ],
-      "fileSize": 703785
-    },
-    {
-      "path": "mods/BadOptimizations-2.4.1-1.21.11.jar",
-      "hashes": {
-        "sha512": "ff91f1866f21a13a32d379080b8efb5d4e07577591228c1d307b34d052696c9bdcbaf7706208dfbac56abc2c29482a15edcbf11f69fc0a01e459c4c20a5c2c28",
-        "sha1": "70fa28d5a7a1fdd61dd804ca6ac411750da1473f"
+        "sha512": "d7f035d6112eaac92cf0f11e4426db631fca5a7115dd355c2126efee4255b648a0102552bbf7b22a7eae9203d08f8740435842bfddcd94e2434f51b57ee9c641",
+        "sha1": "e8865210ba9a926fc206ab9e73f9d4988a81ff69"
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/g96Z4WVZ/versions/Q3Dusz2j/BadOptimizations-2.4.1-1.21.11.jar"
+        "https://cdn.modrinth.com/data/AANobbMI/versions/UddlN6L4/sodium-fabric-0.8.7%2Bmc1.21.11.jar"
       ],
-      "fileSize": 269545
+      "fileSize": 1870358
     },
     {
       "path": "mods/fabric-api-0.141.3+1.21.11.jar",
@@ -192,8 +192,8 @@
         "sha512": "c20c017e23d6d2774690d0dd774cec84c16bfac5461da2d9345a1cd95eee495b1954333c421e3d1c66186284d24a433f6b0cced8021f62e0bfa617d2384d0471"
       },
       "env": {
-        "client": "required",
-        "server": "required"
+        "server": "required",
+        "client": "required"
       },
       "downloads": [
         "https://cdn.modrinth.com/data/P7dR8mSH/versions/i5tSkVBH/fabric-api-0.141.3%2B1.21.11.jar"
@@ -201,23 +201,23 @@
       "fileSize": 2412693
     },
     {
-      "path": "mods/lithium-fabric-0.21.4+mc1.21.11.jar",
+      "path": "mods/modernfix-5.26.2-build.1.jar",
       "hashes": {
-        "sha512": "f14a5c3d2fad786347ca25083f902139694f618b7c103947f2fd067a7c5ee88a63e1ef8926f7d693ea79ed7d00f57317bae77ef9c2d630bf5ed01ac97a752b94",
-        "sha1": "203bdcb26e97b3217b045e1182651a7d7b6462ec"
+        "sha1": "959efa1690550b4e09616f808d5a5ee52c47477f",
+        "sha512": "d57be559b6d2ee802df3617a7d44586f690db27998cfc04f195ec645a754a9be9fcd7e824313671711b0e318720f39f0e96db46727a21ff17b4fa3187fbdf399"
       },
       "env": {
-        "client": "required",
-        "server": "required"
+        "server": "required",
+        "client": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/data/gvQqBUqZ/versions/Ow7wA0kG/lithium-fabric-0.21.4%2Bmc1.21.11.jar"
+        "https://cdn.modrinth.com/data/TjSm1wrD/versions/6q6pkhVP/modernfix-5.26.2-build.1.jar"
       ],
-      "fileSize": 900462
+      "fileSize": 627253
     }
   ],
   "dependencies": {
-    "quilt-loader": "0.30.0-beta.3",
+    "quilt-loader": "0.30.0-beta.7",
     "minecraft": "1.21.11"
   }
 }


### PR DESCRIPTION
Added Fast Noise to the following Photon versions:
- Quilt-1.19.4-1.2.0
- Quilt-1.20.1-1.2.0
- Quilt-1.20.4-1.2.0
- Quilt-1.21.1-1.3.0
- Quilt-1.21.11-1.1.0
- Fabric-1.19.4-1.2.0
- Fabric-1.20.1-1.2.0
- Fabric-1.20.4-1.2.0
- Fabric-1.21.1-1.3.0
- Fabric-1.21.11-1.1.0
- Fabric-26.1.2-0.2.0
- NeoForge-26.1.2-0.2.0

These builds also removed Noisium and NoisiumForked in favor of Fast Noise. Additionally, updated the MODLIST to address these changes.

Closes #42